### PR TITLE
Fix LA times name issue #106

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Want to submit a useful code-chunk? Please submit as a [Pull Request](https://gi
 | [:link:](https://cran.r-project.org/web/packages/fivethirtyeight/fivethirtyeight.pdf) | The `fivethirtyeight` data package 
 | [:link:](https://github.com/TheUpshot) | The Upshot by NY Times |
 | [:link:](https://github.com/baltimore-sun-data) | The Baltimore Sun Data Desk |
-| [:link:](https://github.com/datadesk) | The LA Times Sun Data Desk |
+| [:link:](https://github.com/datadesk) | The LA Times Data Desk |
 | [:link:](https://github.com/OpenNewsLabs/news-graphics-team) | Open News Labs |
 | [:link:](https://t.co/BMvJO2dT1o) | BBC Data Journalism team |
 


### PR DESCRIPTION
This commit fixes issue https://github.com/rfordatascience/tidytuesday/issues/106#issue-483018572