### PR TITLE
Description for `year` variable seems to be wrong

### DIFF
--- a/data/2020/2020-02-25/readme.md
+++ b/data/2020/2020-02-25/readme.md
@@ -40,7 +40,7 @@ measles <- tuesdata$measles
 |:--------|:---------|:-----------|
 |index    |double    | Index ID |
 |state    |character | School's state |
-|year     |character | School's district|
+|year     |character | School academic year|
 |name     |character | School name|
 |type     |character | Whether a school is public, private, charter |
 |city     |character | City |


### PR DESCRIPTION
suggest change to "academic year"

Note that the data at `year` do not appear to be districts

```r
> df_measles %>% pull(year) %>% unique
[1] "2018-19" "2017-18" "null"    "2017"   
```