### PR TITLE
Remove double "<-" from Get the data

### DIFF
--- a/data/2020/2020-06-16/readme.md
+++ b/data/2020/2020-06-16/readme.md
@@ -79,8 +79,8 @@ There are additional full text of [perspectives](https://www.blackpast.org/afric
 
 blackpast <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-06-16/blackpast.csv')
 census <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-06-16/census.csv')
-slave_routes <- <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-06-16/slave_routes.csv')
-african_names <- <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-06-16/african_names.csv')
+slave_routes <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-06-16/slave_routes.csv')
+african_names <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-06-16/african_names.csv')
 
 # Or read in with tidytuesdayR package (https://github.com/thebioengineer/tidytuesdayR)
 


### PR DESCRIPTION
On the slave_routes, and african_names data sets, there were two "<-" I removed the extra one so others can just copy/paste.