### PR TITLE
Correct name of data in `tuesdata`

### DIFF
--- a/data/2021/2021-03-09/readme.md
+++ b/data/2021/2021-03-09/readme.md
@@ -27,7 +27,7 @@ The data this week comes from [FiveThirtyEight](https://github.com/fivethirtyeig
 tuesdata <- tidytuesdayR::tt_load('2021-03-09')
 tuesdata <- tidytuesdayR::tt_load(2021, week = 11)
 
-bechdel <- tuesdata$bechdel
+bechdel <- tuesdata$raw_bechdel
 
 # Or read in the data manually
 


### PR DESCRIPTION
When I run `tuesdata <- tidytuesdayR::tt_load(2021, week = 11)`, the resulting object has a slot called `raw_bechdel` but not `bechdel` as listed in the README