### PR TITLE
2022 W22 changed data source?

### DIFF
--- a/data/2022/2022-05-31/axios.csv
+++ b/data/2022/2022-05-31/axios.csv
@@ -29,16 +29,16 @@ Samsung,Tech,6,80.5,25,2018,35,70.1
 Samsung,Tech,6,80.5,25,2019,7,73.2
 Samsung,Tech,6,80.5,25,2020,22,69.8
 Samsung,Tech,6,80.5,25,2021,31,77.5
-Amazon.com,Ecommerce,7,80.3,3,2017,1,86.27
-Amazon.com,Ecommerce,7,80.3,3,2018,1,83.22
-Amazon.com,Ecommerce,7,80.3,3,2019,2,82.3
-Amazon.com,Ecommerce,7,80.3,3,2020,3,81.4
-Amazon.com,Ecommerce,7,80.3,3,2021,10,80
-Toyota Motor Corporation,Automotive,8,80.3,10,2017,16,80.21
-Toyota Motor Corporation,Automotive,8,80.3,10,2018,42,76.1
-Toyota Motor Corporation,Automotive,8,80.3,10,2019,37,75.9
-Toyota Motor Corporation,Automotive,8,80.3,10,2020,15,78.5
-Toyota Motor Corporation,Automotive,8,80.3,10,2021,18,78.7
+Toyota Motor Corporation,Automotive,7,80.3,11,2017,16,80.21
+Toyota Motor Corporation,Automotive,7,80.3,11,2018,42,76.1
+Toyota Motor Corporation,Automotive,7,80.3,11,2019,37,75.9
+Toyota Motor Corporation,Automotive,7,80.3,11,2020,15,78.5
+Toyota Motor Corporation,Automotive,7,80.3,11,2021,18,78.7
+Amazon.com,Ecommerce,8,80.3,2,2017,1,86.27
+Amazon.com,Ecommerce,8,80.3,2,2018,1,83.22
+Amazon.com,Ecommerce,8,80.3,2,2019,2,82.3
+Amazon.com,Ecommerce,8,80.3,2,2020,3,81.4
+Amazon.com,Ecommerce,8,80.3,2,2021,10,80
 Honda Motor Company,Automotive,9,80.1,-7,2017,30,77.8
 Honda Motor Company,Automotive,9,80.1,-7,2018,19,79.6
 Honda Motor Company,Automotive,9,80.1,-7,2019,36,76
@@ -74,21 +74,21 @@ Microsoft,Tech,15,79,21,2018,11,80.42
 Microsoft,Tech,15,79,21,2019,9,79.7
 Microsoft,Tech,15,79,21,2020,19,77.8
 Microsoft,Tech,15,79,21,2021,36,76.8
-The Home Depot,Retail,16,78.9,29,2017,44,75.5
-The Home Depot,Retail,16,78.9,29,2018,26,78.78
-The Home Depot,Retail,16,78.9,29,2019,12,79.1
-The Home Depot,Retail,16,78.9,29,2020,46,74.6
-The Home Depot,Retail,16,78.9,29,2021,45,75.4
-UPS,Logistics,17,78.9,2,2017,6,82.05
-UPS,Logistics,17,78.9,2,2018,7,81.12
-UPS,Logistics,17,78.9,2,2019,11,79.3
-UPS,Logistics,17,78.9,2,2020,10,79.4
-UPS,Logistics,17,78.9,2,2021,19,78.6
-USAA,Financial Services,18,78.9,-6,2017,11,81.37
-USAA,Financial Services,18,78.9,-6,2018,34,77.78
-USAA,Financial Services,18,78.9,-6,2019,17,78.8
-USAA,Financial Services,18,78.9,-6,2020,21,77.7
-USAA,Financial Services,18,78.9,-6,2021,12,79.2
+UPS,Logistics,16,78.9,3,2017,6,82.05
+UPS,Logistics,16,78.9,3,2018,7,81.12
+UPS,Logistics,16,78.9,3,2019,11,79.3
+UPS,Logistics,16,78.9,3,2020,10,79.4
+UPS,Logistics,16,78.9,3,2021,19,78.6
+USAA,Financial Services,17,78.9,-5,2017,11,81.37
+USAA,Financial Services,17,78.9,-5,2018,34,77.78
+USAA,Financial Services,17,78.9,-5,2019,17,78.8
+USAA,Financial Services,17,78.9,-5,2020,21,77.7
+USAA,Financial Services,17,78.9,-5,2021,12,79.2
+The Home Depot,Retail,18,78.9,27,2017,44,75.5
+The Home Depot,Retail,18,78.9,27,2018,26,78.78
+The Home Depot,Retail,18,78.9,27,2019,12,79.1
+The Home Depot,Retail,18,78.9,27,2020,46,74.6
+The Home Depot,Retail,18,78.9,27,2021,45,75.4
 Publix Supermarkets,Groceries,19,78.8,4,2017,3,82.78
 Publix Supermarkets,Groceries,19,78.8,4,2018,8,80.81
 Publix Supermarkets,Groceries,19,78.8,4,2019,6,80.3
@@ -109,16 +109,16 @@ Netflix,Tech,22,78.5,16,2018,21,79.3
 Netflix,Tech,22,78.5,16,2019,24,77.3
 Netflix,Tech,22,78.5,16,2020,17,78.4
 Netflix,Tech,22,78.5,16,2021,38,76.4
-3M Company,Industrial,23,78.4,2,2017,10,81.5
-3M Company,Industrial,23,78.4,2,2018,NA,81.34
-3M Company,Industrial,23,78.4,2,2019,NA,79.9
-3M Company,Industrial,23,78.4,2,2020,12,78.9
-3M Company,Industrial,23,78.4,2,2021,25,78.1
-General Electric,Industrial,24,78.4,16,2017,28,77.9
-General Electric,Industrial,24,78.4,16,2018,52,74.04
-General Electric,Industrial,24,78.4,16,2019,43,75.3
-General Electric,Industrial,24,78.4,16,2020,26,77
-General Electric,Industrial,24,78.4,16,2021,40,76.1
+General Electric,Industrial,23,78.4,17,2017,28,77.9
+General Electric,Industrial,23,78.4,17,2018,52,74.04
+General Electric,Industrial,23,78.4,17,2019,43,75.3
+General Electric,Industrial,23,78.4,17,2020,26,77
+General Electric,Industrial,23,78.4,17,2021,40,76.1
+3M Company,Industrial,24,78.4,1,2017,10,81.5
+3M Company,Industrial,24,78.4,1,2018,NA,81.34
+3M Company,Industrial,24,78.4,1,2019,NA,79.9
+3M Company,Industrial,24,78.4,1,2020,12,78.9
+3M Company,Industrial,24,78.4,1,2021,25,78.1
 The Kroger Company,Groceries,25,78.4,5,2017,21,79.2
 The Kroger Company,Groceries,25,78.4,5,2018,18,79.67
 The Kroger Company,Groceries,25,78.4,5,2019,21,77.9
@@ -219,11 +219,11 @@ Pfizer,Pharma,44,76.4,-37,2018,NA,71.09
 Pfizer,Pharma,44,76.4,-37,2019,NA,64.2
 Pfizer,Pharma,44,76.4,-37,2020,61,73
 Pfizer,Pharma,44,76.4,-37,2021,7,80.2
-Stellantis,Automotive,45,76.3,NA,2017,NA,NA
-Stellantis,Automotive,45,76.3,NA,2018,NA,NA
-Stellantis,Automotive,45,76.3,NA,2019,NA,NA
-Stellantis,Automotive,45,76.3,NA,2020,NA,NA
-Stellantis,Automotive,45,76.3,NA,2021,NA,NA
+Stellantis,Automotive,45,76.3,30,2017,73,70.02
+Stellantis,Automotive,45,76.3,30,2018,79,66.73
+Stellantis,Automotive,45,76.3,30,2019,85,65.8
+Stellantis,Automotive,45,76.3,30,2020,NA,70.1
+Stellantis,Automotive,45,76.3,30,2021,75,70.8
 American Express,Financial Services,46,76,-2,2017,63,72.9
 American Express,Financial Services,46,76,-2,2018,50,74.27
 American Express,Financial Services,46,76,-2,2019,47,74.6
@@ -244,21 +244,21 @@ Hobby Lobby,Retail,49,75.5,4,2018,44,75.45
 Hobby Lobby,Retail,49,75.5,4,2019,16,78.9
 Hobby Lobby,Retail,49,75.5,4,2020,NA,70.2
 Hobby Lobby,Retail,49,75.5,4,2021,53,74.5
-Best Buy,Retail,50,75.4,-2,2017,46,75.41
-Best Buy,Retail,50,75.4,-2,2018,46,75.19
-Best Buy,Retail,50,75.4,-2,2019,34,76.1
-Best Buy,Retail,50,75.4,-2,2020,47,74.6
-Best Buy,Retail,50,75.4,-2,2021,48,75.2
-General Motors,Automotive,51,75.4,17,2017,77,67.84
-General Motors,Automotive,51,75.4,17,2018,64,70.73
-General Motors,Automotive,51,75.4,17,2019,70,70.2
-General Motors,Automotive,51,75.4,17,2020,54,73.8
-General Motors,Automotive,51,75.4,17,2021,68,72
-T-Mobile,Telecom,52,75.4,NA,2017,NA,NA
-T-Mobile,Telecom,52,75.4,NA,2018,NA,NA
-T-Mobile,Telecom,52,75.4,NA,2019,NA,NA
-T-Mobile,Telecom,52,75.4,NA,2020,NA,70.1
-T-Mobile,Telecom,52,75.4,NA,2021,NA,74.3
+T-Mobile,Telecom,50,75.4,NA,2017,NA,NA
+T-Mobile,Telecom,50,75.4,NA,2018,NA,NA
+T-Mobile,Telecom,50,75.4,NA,2019,NA,NA
+T-Mobile,Telecom,50,75.4,NA,2020,NA,70.1
+T-Mobile,Telecom,50,75.4,NA,2021,NA,74.3
+Best Buy,Retail,51,75.4,-3,2017,46,75.41
+Best Buy,Retail,51,75.4,-3,2018,46,75.19
+Best Buy,Retail,51,75.4,-3,2019,34,76.1
+Best Buy,Retail,51,75.4,-3,2020,47,74.6
+Best Buy,Retail,51,75.4,-3,2021,48,75.2
+General Motors,Automotive,52,75.4,16,2017,77,67.84
+General Motors,Automotive,52,75.4,16,2018,64,70.73
+General Motors,Automotive,52,75.4,16,2019,70,70.2
+General Motors,Automotive,52,75.4,16,2020,54,73.8
+General Motors,Automotive,52,75.4,16,2021,68,72
 Yum! Brands,Food & Beverage,53,75.3,17,2017,61,73.2
 Yum! Brands,Food & Beverage,53,75.3,17,2018,53,74.02
 Yum! Brands,Food & Beverage,53,75.3,17,2019,68,71.4

--- a/data/2022/2022-05-31/readme.md
+++ b/data/2022/2022-05-31/readme.md
@@ -109,7 +109,7 @@ library(gt)
 library(gtExtras)
 
 tab_url <- "https://graphics.axios.com/2022-05-16-harris-poll/index.html?initialWidth=469&childId=av-2022-05-16-harris-poll-69AC2&parentTitle=The%202022%20Axios%20Harris%20Poll%20100%20reputation%20rankings&parentUrl=https%3A%2F%2Fwww.axios.com%2F2022%2F05%2F24%2F2022-axios-harris-poll-100-rankings"
-tab_js <- "https://graphics.axios.com/2022-05-16-harris-poll/js/app.57adf1a5a55662f9bc9f.min.js?57adf1a5a55662f9bc9f"
+tab_js <- "https://graphics.axios.com/2022-05-16-harris-poll/js/app.a8dd96951f9ea55e4346.min.js?a8dd96951f9ea55e4346"
 
 raw_txt <- readLines(tab_js)
 

--- a/data/2022/2022-05-31/reputation.csv
+++ b/data/2022/2022-05-31/reputation.csv
@@ -1,599 +1,599 @@
 company,industry,name,score,rank
-Trader Joe's,Retail,TRUST,82.7,3
+Trader Joe's,Retail,TRUST,82.72,3
 Trader Joe's,Retail,ETHICS,82.5,2
-Trader Joe's,Retail,GROWTH,84.1,2
-Trader Joe's,Retail,P&S,83.5,9
-Trader Joe's,Retail,CITIZENSHIP,80,3
-Trader Joe's,Retail,VISION,81.9,13
-Trader Joe's,Retail,CULTURE,83.1,1
-HEB Grocery,Retail,TRUST,83.7,1
-HEB Grocery,Retail,ETHICS,81.8,4
-HEB Grocery,Retail,GROWTH,83.6,4
-HEB Grocery,Retail,P&S,83.1,11
-HEB Grocery,Retail,CITIZENSHIP,81,1
-HEB Grocery,Retail,VISION,81.3,19
-HEB Grocery,Retail,CULTURE,81,8
-Patagonia,Retail,TRUST,81.3,4
-Patagonia,Retail,ETHICS,81.7,5
-Patagonia,Retail,GROWTH,81.9,15
-Patagonia,Retail,P&S,83.7,5
-Patagonia,Retail,CITIZENSHIP,80.8,2
+Trader Joe's,Retail,GROWTH,84.11,2
+Trader Joe's,Retail,P&S,83.51,10
+Trader Joe's,Retail,CITIZENSHIP,79.96,3
+Trader Joe's,Retail,VISION,81.94,13
+Trader Joe's,Retail,CULTURE,83.05,1
+HEB Grocery,Retail,TRUST,83.74,1
+HEB Grocery,Retail,ETHICS,81.75,4
+HEB Grocery,Retail,GROWTH,83.61,4
+HEB Grocery,Retail,P&S,83.08,11
+HEB Grocery,Retail,CITIZENSHIP,80.97,1
+HEB Grocery,Retail,VISION,81.34,19
+HEB Grocery,Retail,CULTURE,80.99,9
+Patagonia,Retail,TRUST,81.25,5
+Patagonia,Retail,ETHICS,81.72,5
+Patagonia,Retail,GROWTH,81.93,15
+Patagonia,Retail,P&S,83.66,6
+Patagonia,Retail,CITIZENSHIP,80.75,2
 Patagonia,Retail,VISION,82.2,11
-Patagonia,Retail,CULTURE,82.9,3
-The Hershey Company,Food & Beverage,TRUST,79.9,13
-The Hershey Company,Food & Beverage,ETHICS,79.8,11
-The Hershey Company,Food & Beverage,GROWTH,82.3,12
-The Hershey Company,Food & Beverage,P&S,81.4,18
-The Hershey Company,Food & Beverage,CITIZENSHIP,75.2,21
-The Hershey Company,Food & Beverage,VISION,81.8,14
-The Hershey Company,Food & Beverage,CULTURE,79.1,23
-Wegmans,Groceries,TRUST,80.7,7
-Wegmans,Groceries,ETHICS,81.4,6
+Patagonia,Retail,CULTURE,82.85,3
+The Hershey Company,Food & Beverage,TRUST,82.79,2
+The Hershey Company,Food & Beverage,ETHICS,82.42,3
+The Hershey Company,Food & Beverage,GROWTH,82.2,13
+The Hershey Company,Food & Beverage,P&S,84.29,2
+The Hershey Company,Food & Beverage,CITIZENSHIP,77.08,8
+The Hershey Company,Food & Beverage,VISION,84.77,1
+The Hershey Company,Food & Beverage,CULTURE,81.54,6
+Wegmans,Groceries,TRUST,80.74,7
+Wegmans,Groceries,ETHICS,81.41,6
 Wegmans,Groceries,GROWTH,83.1,7
-Wegmans,Groceries,P&S,81.1,21
-Wegmans,Groceries,CITIZENSHIP,78.6,4
-Wegmans,Groceries,VISION,80.9,23
-Wegmans,Groceries,CULTURE,81.7,4
-Samsung,Tech,TRUST,79.8,14
-Samsung,Tech,ETHICS,80.2,9
-Samsung,Tech,GROWTH,83.8,3
-Samsung,Tech,P&S,84.3,2
-Samsung,Tech,CITIZENSHIP,75,23
-Samsung,Tech,VISION,84.1,4
-Samsung,Tech,CULTURE,81.6,5
-Amazon.com,Ecommerce,TRUST,79.9,10
-Amazon.com,Ecommerce,ETHICS,78.9,18
-Amazon.com,Ecommerce,GROWTH,82.9,9
-Amazon.com,Ecommerce,P&S,81.8,14
-Amazon.com,Ecommerce,CITIZENSHIP,77,9
-Amazon.com,Ecommerce,VISION,84.1,2
-Amazon.com,Ecommerce,CULTURE,79.1,21
-Toyota Motor Corporation,Automotive,TRUST,78.7,22
-Toyota Motor Corporation,Automotive,ETHICS,79.7,14
-Toyota Motor Corporation,Automotive,GROWTH,83.5,5
-Toyota Motor Corporation,Automotive,P&S,83.6,7
-Toyota Motor Corporation,Automotive,CITIZENSHIP,76.6,16
-Toyota Motor Corporation,Automotive,VISION,82.4,8
-Toyota Motor Corporation,Automotive,CULTURE,80.2,16
+Wegmans,Groceries,P&S,81.12,22
+Wegmans,Groceries,CITIZENSHIP,78.64,4
+Wegmans,Groceries,VISION,80.89,23
+Wegmans,Groceries,CULTURE,81.69,4
+Samsung,Tech,TRUST,79.83,14
+Samsung,Tech,ETHICS,80.22,9
+Samsung,Tech,GROWTH,83.77,3
+Samsung,Tech,P&S,84.25,4
+Samsung,Tech,CITIZENSHIP,74.97,23
+Samsung,Tech,VISION,84.13,4
+Samsung,Tech,CULTURE,81.63,5
+Toyota Motor Corporation,Automotive,TRUST,78.74,22
+Toyota Motor Corporation,Automotive,ETHICS,79.71,12
+Toyota Motor Corporation,Automotive,GROWTH,83.48,5
+Toyota Motor Corporation,Automotive,P&S,83.61,7
+Toyota Motor Corporation,Automotive,CITIZENSHIP,76.58,16
+Toyota Motor Corporation,Automotive,VISION,82.4,9
+Toyota Motor Corporation,Automotive,CULTURE,80.19,16
+Amazon.com,Ecommerce,TRUST,79.87032,12
+Amazon.com,Ecommerce,ETHICS,78.90624,18
+Amazon.com,Ecommerce,GROWTH,82.93869,9
+Amazon.com,Ecommerce,P&S,81.77067,14
+Amazon.com,Ecommerce,CITIZENSHIP,77.0337,9
+Amazon.com,Ecommerce,VISION,84.13452,2
+Amazon.com,Ecommerce,CULTURE,79.13799,21
 Honda Motor Company,Automotive,TRUST,78.9,20
 Honda Motor Company,Automotive,ETHICS,79.7,13
-Honda Motor Company,Automotive,GROWTH,83,8
-Honda Motor Company,Automotive,P&S,83.6,8
-Honda Motor Company,Automotive,CITIZENSHIP,74.2,28
-Honda Motor Company,Automotive,VISION,82.4,9
-Honda Motor Company,Automotive,CULTURE,81.5,7
-Sony,Tech,TRUST,78.2,27
-Sony,Tech,ETHICS,77.2,40
-Sony,Tech,GROWTH,81,28
-Sony,Tech,P&S,83.5,10
-Sony,Tech,CITIZENSHIP,73.5,34
-Sony,Tech,VISION,80.1,32
-Sony,Tech,CULTURE,79.5,18
-IBM,Tech,TRUST,79.1,18
-IBM,Tech,ETHICS,79.7,12
-IBM,Tech,GROWTH,81.1,26
-IBM,Tech,P&S,82.7,12
-IBM,Tech,CITIZENSHIP,74.6,24
-IBM,Tech,VISION,80.5,26
-IBM,Tech,CULTURE,83,2
-Tesla Motors,Automotive,TRUST,75.7,51
-Tesla Motors,Automotive,ETHICS,75.2,54
-Tesla Motors,Automotive,GROWTH,79.4,39
-Tesla Motors,Automotive,P&S,77.7,54
-Tesla Motors,Automotive,CITIZENSHIP,71.4,56
-Tesla Motors,Automotive,VISION,75.6,63
-Tesla Motors,Automotive,CULTURE,79,25
+Honda Motor Company,Automotive,GROWTH,83.02,8
+Honda Motor Company,Automotive,P&S,83.58,8
+Honda Motor Company,Automotive,CITIZENSHIP,74.19,28
+Honda Motor Company,Automotive,VISION,82.42,8
+Honda Motor Company,Automotive,CULTURE,81.49,7
+Sony,Tech,TRUST,78.2,26
+Sony,Tech,ETHICS,77.17,40
+Sony,Tech,GROWTH,80.96,29
+Sony,Tech,P&S,83.52,9
+Sony,Tech,CITIZENSHIP,73.51,35
+Sony,Tech,VISION,80.07,31
+Sony,Tech,CULTURE,79.52,17
+IBM,Tech,TRUST,79.06,18
+IBM,Tech,ETHICS,79.67,14
+IBM,Tech,GROWTH,81.1,27
+IBM,Tech,P&S,82.65,12
+IBM,Tech,CITIZENSHIP,74.6,25
+IBM,Tech,VISION,80.51,25
+IBM,Tech,CULTURE,83.03,2
+Tesla Motors,Automotive,TRUST,75.03,55
+Tesla Motors,Automotive,ETHICS,77.38,36
+Tesla Motors,Automotive,GROWTH,84.92,1
+Tesla Motors,Automotive,P&S,84.51,1
+Tesla Motors,Automotive,CITIZENSHIP,72.2,50
+Tesla Motors,Automotive,VISION,84.12,5
+Tesla Motors,Automotive,CULTURE,80.54,14
 Blue Cross Blue Shield Association,Healthcare,TRUST,79.9,11
-Blue Cross Blue Shield Association,Healthcare,ETHICS,79,15
-Blue Cross Blue Shield Association,Healthcare,GROWTH,81.9,16
-Blue Cross Blue Shield Association,Healthcare,P&S,80.1,32
-Blue Cross Blue Shield Association,Healthcare,CITIZENSHIP,76.8,13
-Blue Cross Blue Shield Association,Healthcare,VISION,80.5,25
-Blue Cross Blue Shield Association,Healthcare,CULTURE,81,9
-Berkshire Hathaway,Other,TRUST,78,29
-Berkshire Hathaway,Other,ETHICS,80.5,7
+Blue Cross Blue Shield Association,Healthcare,ETHICS,79.01,16
+Blue Cross Blue Shield Association,Healthcare,GROWTH,81.85,17
+Blue Cross Blue Shield Association,Healthcare,P&S,80.08,33
+Blue Cross Blue Shield Association,Healthcare,CITIZENSHIP,76.77,12
+Blue Cross Blue Shield Association,Healthcare,VISION,80.48,26
+Blue Cross Blue Shield Association,Healthcare,CULTURE,81.01,8
+Berkshire Hathaway,Other,TRUST,78.01,29
+Berkshire Hathaway,Other,ETHICS,80.47,7
 Berkshire Hathaway,Other,GROWTH,82.3,11
-Berkshire Hathaway,Other,P&S,78.6,41
-Berkshire Hathaway,Other,CITIZENSHIP,76.4,17
-Berkshire Hathaway,Other,VISION,83.5,6
-Berkshire Hathaway,Other,CULTURE,80.9,10
-Microsoft,Tech,TRUST,79.9,12
-Microsoft,Tech,ETHICS,78.9,19
-Microsoft,Tech,GROWTH,82.9,10
-Microsoft,Tech,P&S,81.8,15
-Microsoft,Tech,CITIZENSHIP,77,10
-Microsoft,Tech,VISION,84.1,3
-Microsoft,Tech,CULTURE,79.1,22
-The Home Depot,Retail,TRUST,77,34
-The Home Depot,Retail,ETHICS,76.7,45
-The Home Depot,Retail,GROWTH,79.2,43
-The Home Depot,Retail,P&S,80.1,33
-The Home Depot,Retail,CITIZENSHIP,73.5,35
-The Home Depot,Retail,VISION,78.5,47
-The Home Depot,Retail,CULTURE,74.5,58
-UPS,Logistics,TRUST,79.4,16
-UPS,Logistics,ETHICS,79,16
-UPS,Logistics,GROWTH,82.2,14
-UPS,Logistics,P&S,80.4,28
-UPS,Logistics,CITIZENSHIP,77.7,6
+Berkshire Hathaway,Other,P&S,78.64,41
+Berkshire Hathaway,Other,CITIZENSHIP,76.42,17
+Berkshire Hathaway,Other,VISION,83.48,6
+Berkshire Hathaway,Other,CULTURE,80.87,11
+Microsoft,Tech,TRUST,79.87032,13
+Microsoft,Tech,ETHICS,78.90624,19
+Microsoft,Tech,GROWTH,82.93869,10
+Microsoft,Tech,P&S,81.77067,15
+Microsoft,Tech,CITIZENSHIP,77.0337,10
+Microsoft,Tech,VISION,84.13452,3
+Microsoft,Tech,CULTURE,79.13799,22
+UPS,Logistics,TRUST,79.43,16
+UPS,Logistics,ETHICS,79.02,15
+UPS,Logistics,GROWTH,82.19,14
+UPS,Logistics,P&S,80.44,28
+UPS,Logistics,CITIZENSHIP,77.74,6
 UPS,Logistics,VISION,81.5,17
-UPS,Logistics,CULTURE,80.5,15
-USAA,Financial Services,TRUST,80.1,9
-USAA,Financial Services,ETHICS,82.7,1
-USAA,Financial Services,GROWTH,81.8,18
+UPS,Logistics,CULTURE,80.51,15
+USAA,Financial Services,TRUST,80.09,9
+USAA,Financial Services,ETHICS,82.68,1
+USAA,Financial Services,GROWTH,81.76,18
 USAA,Financial Services,P&S,80.5,27
-USAA,Financial Services,CITIZENSHIP,78.3,5
-USAA,Financial Services,VISION,80.4,28
-USAA,Financial Services,CULTURE,80.9,12
-Publix Supermarkets,Groceries,TRUST,80.8,6
-Publix Supermarkets,Groceries,ETHICS,80,10
-Publix Supermarkets,Groceries,GROWTH,81.3,23
-Publix Supermarkets,Groceries,P&S,79.1,37
-Publix Supermarkets,Groceries,CITIZENSHIP,76.7,14
-Publix Supermarkets,Groceries,VISION,79.5,36
-Publix Supermarkets,Groceries,CULTURE,78.5,28
-Subaru,Automotive,TRUST,77.7,31
-Subaru,Automotive,ETHICS,78.9,20
-Subaru,Automotive,GROWTH,81.4,21
-Subaru,Automotive,P&S,80.7,25
-Subaru,Automotive,CITIZENSHIP,76.8,12
-Subaru,Automotive,VISION,80.1,30
-Subaru,Automotive,CULTURE,79.4,19
-Apple,Tech,TRUST,75.4,54
-Apple,Tech,ETHICS,77.6,34
-Apple,Tech,GROWTH,81.9,17
-Apple,Tech,P&S,83.7,6
-Apple,Tech,CITIZENSHIP,72.3,49
+USAA,Financial Services,CITIZENSHIP,78.26,5
+USAA,Financial Services,VISION,80.43,28
+USAA,Financial Services,CULTURE,80.87,10
+The Home Depot,Retail,TRUST,79.92,10
+The Home Depot,Retail,ETHICS,79.79,11
+The Home Depot,Retail,GROWTH,82.28,12
+The Home Depot,Retail,P&S,81.37,20
+The Home Depot,Retail,CITIZENSHIP,75.19,21
+The Home Depot,Retail,VISION,81.78,15
+The Home Depot,Retail,CULTURE,79.06,24
+Publix Supermarkets,Groceries,TRUST,80.83,6
+Publix Supermarkets,Groceries,ETHICS,79.97,10
+Publix Supermarkets,Groceries,GROWTH,81.29,23
+Publix Supermarkets,Groceries,P&S,79.07,37
+Publix Supermarkets,Groceries,CITIZENSHIP,76.65,15
+Publix Supermarkets,Groceries,VISION,79.51,37
+Publix Supermarkets,Groceries,CULTURE,78.54,28
+Subaru,Automotive,TRUST,77.69,31
+Subaru,Automotive,ETHICS,78.89,20
+Subaru,Automotive,GROWTH,81.35,22
+Subaru,Automotive,P&S,80.68,25
+Subaru,Automotive,CITIZENSHIP,76.75,13
+Subaru,Automotive,VISION,80.07,30
+Subaru,Automotive,CULTURE,79.43,19
+Apple,Tech,TRUST,75.44,54
+Apple,Tech,ETHICS,77.55,34
+Apple,Tech,GROWTH,81.92,16
+Apple,Tech,P&S,83.7,5
+Apple,Tech,CITIZENSHIP,72.29,49
 Apple,Tech,VISION,82.2,12
-Apple,Tech,CULTURE,77.9,30
-Netflix,Tech,TRUST,78.5,23
-Netflix,Tech,ETHICS,76.8,43
-Netflix,Tech,GROWTH,81.4,22
-Netflix,Tech,P&S,81.4,19
-Netflix,Tech,CITIZENSHIP,73.6,33
-Netflix,Tech,VISION,81.8,15
-Netflix,Tech,CULTURE,77.8,35
-3M Company,Industrial,TRUST,75.8,49
+Apple,Tech,CULTURE,77.88,34
+Netflix,Tech,TRUST,78.46,23
+Netflix,Tech,ETHICS,76.78,43
+Netflix,Tech,GROWTH,81.4,21
+Netflix,Tech,P&S,81.44,18
+Netflix,Tech,CITIZENSHIP,73.58,33
+Netflix,Tech,VISION,81.83,14
+Netflix,Tech,CULTURE,77.83,35
+General Electric,Industrial,TRUST,78.39,24
+General Electric,Industrial,ETHICS,77.99,30
+General Electric,Industrial,GROWTH,79.51,37
+General Electric,Industrial,P&S,82,13
+General Electric,Industrial,CITIZENSHIP,73.23,38
+General Electric,Industrial,VISION,80.46,27
+General Electric,Industrial,CULTURE,80.85,12
+3M Company,Industrial,TRUST,75.8,50
 3M Company,Industrial,ETHICS,76,49
 3M Company,Industrial,GROWTH,79.2,44
-3M Company,Industrial,P&S,84.3,4
-3M Company,Industrial,CITIZENSHIP,73.2,38
+3M Company,Industrial,P&S,84.3,3
+3M Company,Industrial,CITIZENSHIP,73.2,41
 3M Company,Industrial,VISION,78.4,49
-3M Company,Industrial,CULTURE,77.9,34
-General Electric,Industrial,TRUST,78.4,25
-General Electric,Industrial,ETHICS,78,29
-General Electric,Industrial,GROWTH,79.5,37
-General Electric,Industrial,P&S,82,13
-General Electric,Industrial,CITIZENSHIP,73.2,39
-General Electric,Industrial,VISION,80.5,27
-General Electric,Industrial,CULTURE,80.9,11
-The Kroger Company,Groceries,TRUST,52.9,100
-The Kroger Company,Groceries,ETHICS,51.2,100
-The Kroger Company,Groceries,GROWTH,55.1,100
-The Kroger Company,Groceries,P&S,55.7,100
-The Kroger Company,Groceries,CITIZENSHIP,53.6,100
-The Kroger Company,Groceries,VISION,59.4,100
-The Kroger Company,Groceries,CULTURE,53,100
-Costco,Retail,TRUST,79,19
-Costco,Retail,ETHICS,78.5,24
-Costco,Retail,GROWTH,80.6,34
+3M Company,Industrial,CULTURE,77.9,33
+The Kroger Company,Groceries,TRUST,80.27,8
+The Kroger Company,Groceries,ETHICS,77.19,39
+The Kroger Company,Groceries,GROWTH,81.48,20
+The Kroger Company,Groceries,P&S,80.69,24
+The Kroger Company,Groceries,CITIZENSHIP,76.8,11
+The Kroger Company,Groceries,VISION,80.05,32
+The Kroger Company,Groceries,CULTURE,77.9,32
+Costco,Retail,TRUST,79.01,19
+Costco,Retail,ETHICS,78.53,24
+Costco,Retail,GROWTH,80.63,33
 Costco,Retail,P&S,79.2,36
-Costco,Retail,CITIZENSHIP,74.4,26
-Costco,Retail,VISION,79.1,42
-Costco,Retail,CULTURE,79.3,20
-LG Corporation,Tech,TRUST,78.2,26
-LG Corporation,Tech,ETHICS,78.1,26
-LG Corporation,Tech,GROWTH,81.3,24
-LG Corporation,Tech,P&S,80.4,29
-LG Corporation,Tech,CITIZENSHIP,74,30
-LG Corporation,Tech,VISION,79,46
-LG Corporation,Tech,CULTURE,76.8,44
-Chick-fil-A,Food & Beverage,TRUST,79.1,17
+Costco,Retail,CITIZENSHIP,74.42,26
+Costco,Retail,VISION,79.14,42
+Costco,Retail,CULTURE,79.31,20
+LG Corporation,Tech,TRUST,78.16,27
+LG Corporation,Tech,ETHICS,78.12,26
+LG Corporation,Tech,GROWTH,81.28,24
+LG Corporation,Tech,P&S,80.41,29
+LG Corporation,Tech,CITIZENSHIP,73.98,30
+LG Corporation,Tech,VISION,79.04,46
+LG Corporation,Tech,CULTURE,76.77,44
+Chick-fil-A,Food & Beverage,TRUST,79.12,17
 Chick-fil-A,Food & Beverage,ETHICS,78.8,21
-Chick-fil-A,Food & Beverage,GROWTH,80.6,33
-Chick-fil-A,Food & Beverage,P&S,80.6,26
-Chick-fil-A,Food & Beverage,CITIZENSHIP,73.7,31
-Chick-fil-A,Food & Beverage,VISION,83.5,7
+Chick-fil-A,Food & Beverage,GROWTH,80.56,34
+Chick-fil-A,Food & Beverage,P&S,80.63,26
+Chick-fil-A,Food & Beverage,CITIZENSHIP,73.65,32
+Chick-fil-A,Food & Beverage,VISION,83.47,7
 Chick-fil-A,Food & Beverage,CULTURE,77,41
-Adidas,Retail,TRUST,77.4,32
-Adidas,Retail,ETHICS,76.5,47
-Adidas,Retail,GROWTH,79.3,40
-Adidas,Retail,P&S,81.1,23
-Adidas,Retail,CITIZENSHIP,75.3,20
-Adidas,Retail,VISION,80.1,31
-Adidas,Retail,CULTURE,78.3,29
-Walgreens,Retail,TRUST,81.3,5
+Adidas,Retail,TRUST,77.42,32
+Adidas,Retail,ETHICS,76.45,47
+Adidas,Retail,GROWTH,79.33,40
+Adidas,Retail,P&S,81.14,21
+Adidas,Retail,CITIZENSHIP,75.34,20
+Adidas,Retail,VISION,80.09,29
+Adidas,Retail,CULTURE,78.34,29
+Walgreens,Retail,TRUST,81.32,4
 Walgreens,Retail,ETHICS,80.3,8
-Walgreens,Retail,GROWTH,81.2,25
-Walgreens,Retail,P&S,80.2,31
+Walgreens,Retail,GROWTH,81.21,25
+Walgreens,Retail,P&S,80.24,31
 Walgreens,Retail,CITIZENSHIP,77.7,7
 Walgreens,Retail,VISION,81.5,18
-Walgreens,Retail,CULTURE,78.7,27
-Google,Tech,TRUST,75.5,53
-Google,Tech,ETHICS,75.6,50
-Google,Tech,GROWTH,83.2,6
-Google,Tech,P&S,81.5,17
-Google,Tech,CITIZENSHIP,72.2,51
-Google,Tech,VISION,81.6,16
-Google,Tech,CULTURE,80.6,13
-Target,Retail,TRUST,75,55
-Target,Retail,ETHICS,77.4,36
-Target,Retail,GROWTH,84.9,1
-Target,Retail,P&S,84.5,1
-Target,Retail,CITIZENSHIP,72.2,50
-Target,Retail,VISION,84.1,5
-Target,Retail,CULTURE,80.5,14
-UnitedHealth Group,Healthcare,TRUST,76.1,46
-UnitedHealth Group,Healthcare,ETHICS,78.1,28
-UnitedHealth Group,Healthcare,GROWTH,81.7,19
-UnitedHealth Group,Healthcare,P&S,78.7,39
-UnitedHealth Group,Healthcare,CITIZENSHIP,75.1,22
-UnitedHealth Group,Healthcare,VISION,81.2,22
+Walgreens,Retail,CULTURE,78.74,27
+Google,Tech,TRUST,75.52,52
+Google,Tech,ETHICS,75.56,50
+Google,Tech,GROWTH,83.23,6
+Google,Tech,P&S,81.49,17
+Google,Tech,CITIZENSHIP,72.16,52
+Google,Tech,VISION,81.57,16
+Google,Tech,CULTURE,80.61,13
+Target,Retail,TRUST,78.8,21
+Target,Retail,ETHICS,78.62,23
+Target,Retail,GROWTH,79.41,38
+Target,Retail,P&S,78.67,39
+Target,Retail,CITIZENSHIP,75.48,19
+Target,Retail,VISION,81.31,20
+Target,Retail,CULTURE,77.18,39
+UnitedHealth Group,Healthcare,TRUST,76.08,46
+UnitedHealth Group,Healthcare,ETHICS,78.07,28
+UnitedHealth Group,Healthcare,GROWTH,81.67,19
+UnitedHealth Group,Healthcare,P&S,78.65,40
+UnitedHealth Group,Healthcare,CITIZENSHIP,75.07,22
+UnitedHealth Group,Healthcare,VISION,81.23,22
 UnitedHealth Group,Healthcare,CULTURE,77.4,38
-Lowe's,Retail,TRUST,79.5,15
-Lowe's,Retail,ETHICS,78.2,25
+Lowe's,Retail,TRUST,79.48,15
+Lowe's,Retail,ETHICS,78.18,25
 Lowe's,Retail,GROWTH,80.2,35
-Lowe's,Retail,P&S,78.2,46
-Lowe's,Retail,CITIZENSHIP,74.6,25
-Lowe's,Retail,VISION,79.8,34
-Lowe's,Retail,CULTURE,77.9,32
-Unilever,Consumer Goods,TRUST,76.6,38
-Unilever,Consumer Goods,ETHICS,75.2,52
-Unilever,Consumer Goods,GROWTH,81,29
-Unilever,Consumer Goods,P&S,79.9,34
-Unilever,Consumer Goods,CITIZENSHIP,74.1,29
-Unilever,Consumer Goods,VISION,79.8,35
-Unilever,Consumer Goods,CULTURE,77.6,37
-CVS (CVS Health),Retail,TRUST,78.4,24
-CVS (CVS Health),Retail,ETHICS,78.6,23
-CVS (CVS Health),Retail,GROWTH,77.4,54
-CVS (CVS Health),Retail,P&S,78.4,43
-CVS (CVS Health),Retail,CITIZENSHIP,76,18
-CVS (CVS Health),Retail,VISION,79.8,33
-CVS (CVS Health),Retail,CULTURE,76.4,47
+Lowe's,Retail,P&S,78.21,46
+Lowe's,Retail,CITIZENSHIP,74.61,24
+Lowe's,Retail,VISION,79.77,34
+Lowe's,Retail,CULTURE,77.93,31
+Unilever,Consumer Goods,TRUST,76.61,36
+Unilever,Consumer Goods,ETHICS,75.23,52
+Unilever,Consumer Goods,GROWTH,80.97,28
+Unilever,Consumer Goods,P&S,79.86,34
+Unilever,Consumer Goods,CITIZENSHIP,74.05,29
+Unilever,Consumer Goods,VISION,79.81,33
+Unilever,Consumer Goods,CULTURE,77.63,37
+CVS (CVS Health),Retail,TRUST,78.38,25
+CVS (CVS Health),Retail,ETHICS,78.64,22
+CVS (CVS Health),Retail,GROWTH,77.44,54
+CVS (CVS Health),Retail,P&S,78.42,43
+CVS (CVS Health),Retail,CITIZENSHIP,75.95,18
+CVS (CVS Health),Retail,VISION,79.75,35
+CVS (CVS Health),Retail,CULTURE,76.42,47
 Procter & Gamble Co.,Consumer Goods,TRUST,76.1,45
 Procter & Gamble Co.,Consumer Goods,ETHICS,74.6,58
 Procter & Gamble Co.,Consumer Goods,GROWTH,80.7,32
-Procter & Gamble Co.,Consumer Goods,P&S,81.4,20
+Procter & Gamble Co.,Consumer Goods,P&S,81.4,19
 Procter & Gamble Co.,Consumer Goods,CITIZENSHIP,73.2,40
 Procter & Gamble Co.,Consumer Goods,VISION,78.4,50
 Procter & Gamble Co.,Consumer Goods,CULTURE,77.7,36
-Dell,Tech,TRUST,75.8,50
-Dell,Tech,ETHICS,77.7,31
-Dell,Tech,GROWTH,77.9,50
+Dell,Tech,TRUST,75.84,49
+Dell,Tech,ETHICS,77.68,31
+Dell,Tech,GROWTH,77.91,50
 Dell,Tech,P&S,80.4,30
-Dell,Tech,CITIZENSHIP,73.7,32
-Dell,Tech,VISION,79.5,37
-Dell,Tech,CULTURE,77.9,33
-FedEx Corporation,Logistics,TRUST,76.5,39
-FedEx Corporation,Logistics,ETHICS,76.9,41
-FedEx Corporation,Logistics,GROWTH,80.9,30
-FedEx Corporation,Logistics,P&S,77.2,56
-FedEx Corporation,Logistics,CITIZENSHIP,74.3,27
-FedEx Corporation,Logistics,VISION,81.3,21
-FedEx Corporation,Logistics,CULTURE,79.5,17
-The Kraft Heinz Company,Food & Beverage,TRUST,80.3,8
-The Kraft Heinz Company,Food & Beverage,ETHICS,77.2,39
-The Kraft Heinz Company,Food & Beverage,GROWTH,81.5,20
-The Kraft Heinz Company,Food & Beverage,P&S,80.7,24
-The Kraft Heinz Company,Food & Beverage,CITIZENSHIP,76.8,11
-The Kraft Heinz Company,Food & Beverage,VISION,80.1,29
-The Kraft Heinz Company,Food & Beverage,CULTURE,77.9,31
-Ford Motor Company,Automotive,TRUST,75.5,52
-Ford Motor Company,Automotive,ETHICS,77.6,33
-Ford Motor Company,Automotive,GROWTH,79.2,42
-Ford Motor Company,Automotive,P&S,78.3,44
-Ford Motor Company,Automotive,CITIZENSHIP,72.8,42
-Ford Motor Company,Automotive,VISION,79.5,38
-Ford Motor Company,Automotive,CULTURE,78.9,26
-Nestle,Consumer Goods,TRUST,76.3,41
+Dell,Tech,CITIZENSHIP,73.74,31
+Dell,Tech,VISION,79.46,39
+Dell,Tech,CULTURE,77.94,30
+FedEx Corporation,Logistics,TRUST,76.48,39
+FedEx Corporation,Logistics,ETHICS,76.91,41
+FedEx Corporation,Logistics,GROWTH,80.85,30
+FedEx Corporation,Logistics,P&S,77.21,56
+FedEx Corporation,Logistics,CITIZENSHIP,74.28,27
+FedEx Corporation,Logistics,VISION,81.28,21
+FedEx Corporation,Logistics,CULTURE,79.51,18
+The Kraft Heinz Company,Food & Beverage,TRUST,76.95,34
+The Kraft Heinz Company,Food & Beverage,ETHICS,76.71,45
+The Kraft Heinz Company,Food & Beverage,GROWTH,79.19,43
+The Kraft Heinz Company,Food & Beverage,P&S,80.09,32
+The Kraft Heinz Company,Food & Beverage,CITIZENSHIP,73.48,36
+The Kraft Heinz Company,Food & Beverage,VISION,78.53,47
+The Kraft Heinz Company,Food & Beverage,CULTURE,74.53,57
+Ford Motor Company,Automotive,TRUST,75.46,53
+Ford Motor Company,Automotive,ETHICS,77.59,33
+Ford Motor Company,Automotive,GROWTH,79.22,42
+Ford Motor Company,Automotive,P&S,78.25,45
+Ford Motor Company,Automotive,CITIZENSHIP,72.84,42
+Ford Motor Company,Automotive,VISION,79.53,36
+Ford Motor Company,Automotive,CULTURE,78.91,26
+Nestle,Consumer Goods,TRUST,76.28,43
 Nestle,Consumer Goods,ETHICS,75.2,53
-Nestle,Consumer Goods,GROWTH,79.3,41
-Nestle,Consumer Goods,P&S,79.3,35
-Nestle,Consumer Goods,CITIZENSHIP,72.5,45
-Nestle,Consumer Goods,VISION,78.1,52
-Nestle,Consumer Goods,CULTURE,77.1,40
-Starbucks Corporation,Food & Beverage,TRUST,73.4,63
-Starbucks Corporation,Food & Beverage,ETHICS,77.5,35
-Starbucks Corporation,Food & Beverage,GROWTH,81.1,27
-Starbucks Corporation,Food & Beverage,P&S,81.1,22
-Starbucks Corporation,Food & Beverage,CITIZENSHIP,70.6,63
+Nestle,Consumer Goods,GROWTH,79.28,41
+Nestle,Consumer Goods,P&S,79.33,35
+Nestle,Consumer Goods,CITIZENSHIP,72.54,45
+Nestle,Consumer Goods,VISION,78.14,52
+Nestle,Consumer Goods,CULTURE,77.11,40
+Starbucks Corporation,Food & Beverage,TRUST,73.38,63
+Starbucks Corporation,Food & Beverage,ETHICS,77.51,35
+Starbucks Corporation,Food & Beverage,GROWTH,81.11,26
+Starbucks Corporation,Food & Beverage,P&S,81.1,23
+Starbucks Corporation,Food & Beverage,CITIZENSHIP,70.63,64
 Starbucks Corporation,Food & Beverage,VISION,82.3,10
 Starbucks Corporation,Food & Beverage,CULTURE,75.7,52
-Pfizer,Pharma,TRUST,73.9,61
-Pfizer,Pharma,ETHICS,74.6,59
-Pfizer,Pharma,GROWTH,80.8,31
-Pfizer,Pharma,P&S,78.6,42
-Pfizer,Pharma,CITIZENSHIP,73.4,37
-Pfizer,Pharma,VISION,79.1,43
-Pfizer,Pharma,CULTURE,76.5,46
-Stellantis,Automotive,TRUST,76.4,40
-Stellantis,Automotive,ETHICS,77.3,38
-Stellantis,Automotive,GROWTH,77.2,55
-Stellantis,Automotive,P&S,76.3,58
-Stellantis,Automotive,CITIZENSHIP,76.7,15
-Stellantis,Automotive,VISION,75.3,67
+Pfizer,Pharma,TRUST,73.93,61
+Pfizer,Pharma,ETHICS,74.62,60
+Pfizer,Pharma,GROWTH,80.75,31
+Pfizer,Pharma,P&S,78.59,42
+Pfizer,Pharma,CITIZENSHIP,73.41,37
+Pfizer,Pharma,VISION,79.11,44
+Pfizer,Pharma,CULTURE,76.48,46
+Stellantis,Automotive,TRUST,76.44,40
+Stellantis,Automotive,ETHICS,77.34,37
+Stellantis,Automotive,GROWTH,77.16,55
+Stellantis,Automotive,P&S,76.32,58
+Stellantis,Automotive,CITIZENSHIP,76.67,14
+Stellantis,Automotive,VISION,75.26,67
 Stellantis,Automotive,CULTURE,76.9,43
-American Express,Financial Services,TRUST,76.2,44
-American Express,Financial Services,ETHICS,78.1,27
-American Express,Financial Services,GROWTH,78.4,49
-American Express,Financial Services,P&S,78.2,48
-American Express,Financial Services,CITIZENSHIP,72.4,47
-American Express,Financial Services,VISION,79.4,40
-American Express,Financial Services,CULTURE,76.7,45
-PepsiCo,Consumer Goods,TRUST,76.3,42
-PepsiCo,Consumer Goods,ETHICS,78,30
-PepsiCo,Consumer Goods,GROWTH,79.1,45
-PepsiCo,Consumer Goods,P&S,77.8,53
+American Express,Financial Services,TRUST,76.18,44
+American Express,Financial Services,ETHICS,78.09,27
+American Express,Financial Services,GROWTH,78.36,49
+American Express,Financial Services,P&S,78.18,48
+American Express,Financial Services,CITIZENSHIP,72.38,48
+American Express,Financial Services,VISION,79.43,40
+American Express,Financial Services,CULTURE,76.69,45
+PepsiCo,Consumer Goods,TRUST,76.29,42
+PepsiCo,Consumer Goods,ETHICS,78,29
+PepsiCo,Consumer Goods,GROWTH,79.11,45
+PepsiCo,Consumer Goods,P&S,77.78,53
 PepsiCo,Consumer Goods,CITIZENSHIP,72.1,53
-PepsiCo,Consumer Goods,VISION,79.1,44
-PepsiCo,Consumer Goods,CULTURE,79.1,24
-JPMorgan Chase & Co.,Financial Services,TRUST,77,33
-JPMorgan Chase & Co.,Financial Services,ETHICS,77.3,37
-JPMorgan Chase & Co.,Financial Services,GROWTH,79,46
-JPMorgan Chase & Co.,Financial Services,P&S,78,50
-JPMorgan Chase & Co.,Financial Services,CITIZENSHIP,72.4,48
-JPMorgan Chase & Co.,Financial Services,VISION,79.5,39
-JPMorgan Chase & Co.,Financial Services,CULTURE,74.5,57
-Hobby Lobby,Retail,TRUST,78,30
-Hobby Lobby,Retail,ETHICS,76.5,46
-Hobby Lobby,Retail,GROWTH,75.3,67
-Hobby Lobby,Retail,P&S,77.6,55
-Hobby Lobby,Retail,CITIZENSHIP,72.6,44
-Hobby Lobby,Retail,VISION,78.3,51
-Hobby Lobby,Retail,CULTURE,74.1,60
-Best Buy,Retail,TRUST,78.1,28
-Best Buy,Retail,ETHICS,75,55
-Best Buy,Retail,GROWTH,75.3,68
-Best Buy,Retail,P&S,78.1,49
-Best Buy,Retail,CITIZENSHIP,72.2,52
-Best Buy,Retail,VISION,74.4,75
-Best Buy,Retail,CULTURE,75.1,54
-General Motors,Automotive,TRUST,75.9,48
+PepsiCo,Consumer Goods,VISION,79.14,43
+PepsiCo,Consumer Goods,CULTURE,79.07,23
+JPMorgan Chase & Co.,Financial Services,TRUST,77.01,33
+JPMorgan Chase & Co.,Financial Services,ETHICS,77.25,38
+JPMorgan Chase & Co.,Financial Services,GROWTH,79.01,46
+JPMorgan Chase & Co.,Financial Services,P&S,77.99,50
+JPMorgan Chase & Co.,Financial Services,CITIZENSHIP,72.41,47
+JPMorgan Chase & Co.,Financial Services,VISION,79.5,38
+JPMorgan Chase & Co.,Financial Services,CULTURE,74.46,58
+Hobby Lobby,Retail,TRUST,77.98,30
+Hobby Lobby,Retail,ETHICS,76.46,46
+Hobby Lobby,Retail,GROWTH,75.31,67
+Hobby Lobby,Retail,P&S,77.57,55
+Hobby Lobby,Retail,CITIZENSHIP,72.62,44
+Hobby Lobby,Retail,VISION,78.31,51
+Hobby Lobby,Retail,CULTURE,74.08,60
+T-Mobile,Telecom,TRUST,73.54,62
+T-Mobile,Telecom,ETHICS,76.9,42
+T-Mobile,Telecom,GROWTH,79.99,36
+T-Mobile,Telecom,P&S,77.9,52
+T-Mobile,Telecom,CITIZENSHIP,72.53,46
+T-Mobile,Telecom,VISION,80.65,24
+T-Mobile,Telecom,CULTURE,76.31,49
+Best Buy,Retail,TRUST,78.14,28
+Best Buy,Retail,ETHICS,74.97,55
+Best Buy,Retail,GROWTH,75.27,69
+Best Buy,Retail,P&S,78.08,49
+Best Buy,Retail,CITIZENSHIP,72.19,51
+Best Buy,Retail,VISION,74.38,76
+Best Buy,Retail,CULTURE,75.09,54
+General Motors,Automotive,TRUST,75.85,48
 General Motors,Automotive,ETHICS,74.8,56
-General Motors,Automotive,GROWTH,78.5,47
-General Motors,Automotive,P&S,78,51
-General Motors,Automotive,CITIZENSHIP,70.6,64
-General Motors,Automotive,VISION,79.4,41
-General Motors,Automotive,CULTURE,77,42
-T-Mobile,Telecom,TRUST,78.8,21
-T-Mobile,Telecom,ETHICS,78.6,22
-T-Mobile,Telecom,GROWTH,79.4,38
-T-Mobile,Telecom,P&S,78.7,40
-T-Mobile,Telecom,CITIZENSHIP,75.5,19
-T-Mobile,Telecom,VISION,81.3,20
-T-Mobile,Telecom,CULTURE,77.2,39
-Yum! Brands,Food & Beverage,TRUST,76.3,43
-Yum! Brands,Food & Beverage,ETHICS,76.3,48
-Yum! Brands,Food & Beverage,GROWTH,77.8,51
-Yum! Brands,Food & Beverage,P&S,76.2,59
-Yum! Brands,Food & Beverage,CITIZENSHIP,73.2,41
-Yum! Brands,Food & Beverage,VISION,76.9,56
-Yum! Brands,Food & Beverage,CULTURE,72.9,66
-Nordstrom,Retail,TRUST,76.8,35
-Nordstrom,Retail,ETHICS,77.6,32
-Nordstrom,Retail,GROWTH,73.2,77
-Nordstrom,Retail,P&S,78.8,38
-Nordstrom,Retail,CITIZENSHIP,70.1,66
-Nordstrom,Retail,VISION,77.4,54
-Nordstrom,Retail,CULTURE,76.3,49
-State Farm Insurance,Financial Services,TRUST,74.6,59
-State Farm Insurance,Financial Services,ETHICS,75.3,51
-State Farm Insurance,Financial Services,GROWTH,75.8,64
-State Farm Insurance,Financial Services,P&S,76.1,61
-State Farm Insurance,Financial Services,CITIZENSHIP,72.8,43
-State Farm Insurance,Financial Services,VISION,77.3,55
-State Farm Insurance,Financial Services,CULTURE,74.3,59
-Nike,Retail,TRUST,72.5,66
-Nike,Retail,ETHICS,70.8,75
-Nike,Retail,GROWTH,77.1,57
-Nike,Retail,P&S,81.6,16
-Nike,Retail,CITIZENSHIP,67.6,79
+General Motors,Automotive,GROWTH,78.47,48
+General Motors,Automotive,P&S,77.98,51
+General Motors,Automotive,CITIZENSHIP,70.64,63
+General Motors,Automotive,VISION,79.42,41
+General Motors,Automotive,CULTURE,76.99,42
+Yum! Brands,Food & Beverage,TRUST,76.33,41
+Yum! Brands,Food & Beverage,ETHICS,76.29,48
+Yum! Brands,Food & Beverage,GROWTH,77.75,51
+Yum! Brands,Food & Beverage,P&S,76.19,59
+Yum! Brands,Food & Beverage,CITIZENSHIP,73.23,39
+Yum! Brands,Food & Beverage,VISION,76.92,56
+Yum! Brands,Food & Beverage,CULTURE,72.92,66
+Nordstrom,Retail,TRUST,76.78,35
+Nordstrom,Retail,ETHICS,77.61,32
+Nordstrom,Retail,GROWTH,73.15,77
+Nordstrom,Retail,P&S,78.79,38
+Nordstrom,Retail,CITIZENSHIP,70.13,66
+Nordstrom,Retail,VISION,77.39,54
+Nordstrom,Retail,CULTURE,76.33,48
+State Farm Insurance,Financial Services,TRUST,74.58,59
+State Farm Insurance,Financial Services,ETHICS,75.33,51
+State Farm Insurance,Financial Services,GROWTH,75.78,64
+State Farm Insurance,Financial Services,P&S,76.07,62
+State Farm Insurance,Financial Services,CITIZENSHIP,72.75,43
+State Farm Insurance,Financial Services,VISION,77.34,55
+State Farm Insurance,Financial Services,CULTURE,74.28,59
+Nike,Retail,TRUST,72.53,66
+Nike,Retail,ETHICS,70.83,75
+Nike,Retail,GROWTH,77.06,56
+Nike,Retail,P&S,81.59,16
+Nike,Retail,CITIZENSHIP,67.64,79
 Nike,Retail,VISION,78.5,48
-Nike,Retail,CULTURE,73.4,61
-Progressive Corporation,Insurance,TRUST,73,65
-Progressive Corporation,Insurance,ETHICS,74.8,57
-Progressive Corporation,Insurance,GROWTH,77,58
-Progressive Corporation,Insurance,P&S,75.9,64
-Progressive Corporation,Insurance,CITIZENSHIP,71.2,60
-Progressive Corporation,Insurance,VISION,79.1,45
-Progressive Corporation,Insurance,CULTURE,75.8,51
-The Coca-Cola Company,Food & Beverage,TRUST,82.8,2
-The Coca-Cola Company,Food & Beverage,ETHICS,82.4,3
-The Coca-Cola Company,Food & Beverage,GROWTH,82.2,13
-The Coca-Cola Company,Food & Beverage,P&S,84.3,3
-The Coca-Cola Company,Food & Beverage,CITIZENSHIP,77.1,8
-The Coca-Cola Company,Food & Beverage,VISION,84.8,1
-The Coca-Cola Company,Food & Beverage,CULTURE,81.5,6
-Spotify,Media,TRUST,74.7,58
-Spotify,Media,ETHICS,71.9,68
-Spotify,Media,GROWTH,78.5,48
-Spotify,Media,P&S,78.2,47
-Spotify,Media,CITIZENSHIP,71.2,59
-Spotify,Media,VISION,75.6,64
+Nike,Retail,CULTURE,73.35,62
+Progressive Corporation,Insurance,TRUST,72.96,65
+Progressive Corporation,Insurance,ETHICS,74.75,57
+Progressive Corporation,Insurance,GROWTH,76.95,58
+Progressive Corporation,Insurance,P&S,75.91,64
+Progressive Corporation,Insurance,CITIZENSHIP,71.17,60
+Progressive Corporation,Insurance,VISION,79.11,45
+Progressive Corporation,Insurance,CULTURE,75.77,51
+The Coca-Cola Company,Food & Beverage,TRUST,75.66,51
+The Coca-Cola Company,Food & Beverage,ETHICS,75.19,54
+The Coca-Cola Company,Food & Beverage,GROWTH,79.38,39
+The Coca-Cola Company,Food & Beverage,P&S,77.65,54
+The Coca-Cola Company,Food & Beverage,CITIZENSHIP,71.42,56
+The Coca-Cola Company,Food & Beverage,VISION,75.58,64
+The Coca-Cola Company,Food & Beverage,CULTURE,79.01,25
+Spotify,Media,TRUST,74.67,57
+Spotify,Media,ETHICS,71.88,68
+Spotify,Media,GROWTH,78.51,47
+Spotify,Media,P&S,78.21,47
+Spotify,Media,CITIZENSHIP,71.22,59
+Spotify,Media,VISION,75.61,63
 Spotify,Media,CULTURE,75.2,53
-Citigroup,Financial Services,TRUST,71.9,72
-Citigroup,Financial Services,ETHICS,72.1,66
-Citigroup,Financial Services,GROWTH,77.6,53
-Citigroup,Financial Services,P&S,76.1,60
-Citigroup,Financial Services,CITIZENSHIP,70.3,65
-Citigroup,Financial Services,VISION,76.9,58
-Citigroup,Financial Services,CULTURE,74.9,56
-Kohl's,Retail,TRUST,76.6,37
-Kohl's,Retail,ETHICS,79,17
+Citigroup,Financial Services,TRUST,71.93,72
+Citigroup,Financial Services,ETHICS,72.13,66
+Citigroup,Financial Services,GROWTH,77.55,53
+Citigroup,Financial Services,P&S,76.09,61
+Citigroup,Financial Services,CITIZENSHIP,70.27,65
+Citigroup,Financial Services,VISION,76.92,57
+Citigroup,Financial Services,CULTURE,74.88,56
+Kohl's,Retail,TRUST,76.56,38
+Kohl's,Retail,ETHICS,78.95,17
 Kohl's,Retail,GROWTH,73.7,75
-Kohl's,Retail,P&S,73.8,71
-Kohl's,Retail,CITIZENSHIP,71.6,55
-Kohl's,Retail,VISION,75.3,68
+Kohl's,Retail,P&S,73.76,71
+Kohl's,Retail,CITIZENSHIP,71.56,55
+Kohl's,Retail,VISION,75.26,68
 Kohl's,Retail,CULTURE,72.9,67
-Royal Dutch Shell,Energy,TRUST,72.3,67
-Royal Dutch Shell,Energy,ETHICS,71.2,74
-Royal Dutch Shell,Energy,GROWTH,77.1,56
-Royal Dutch Shell,Energy,P&S,76.9,57
-Royal Dutch Shell,Energy,CITIZENSHIP,69.7,70
-Royal Dutch Shell,Energy,VISION,74.8,71
+Royal Dutch Shell,Energy,TRUST,72.29,67
+Royal Dutch Shell,Energy,ETHICS,71.16,74
+Royal Dutch Shell,Energy,GROWTH,77.06,57
+Royal Dutch Shell,Energy,P&S,76.89,57
+Royal Dutch Shell,Energy,CITIZENSHIP,69.74,70
+Royal Dutch Shell,Energy,VISION,74.78,72
 Royal Dutch Shell,Energy,CULTURE,76.2,50
-Macy's,Retail,TRUST,74.1,60
-Macy's,Retail,ETHICS,73.8,62
-Macy's,Retail,GROWTH,73.1,79
-Macy's,Retail,P&S,76.1,63
-Macy's,Retail,CITIZENSHIP,71.6,54
-Macy's,Retail,VISION,74.4,76
-Macy's,Retail,CULTURE,72.6,68
-Wendy's,Food & Beverage,TRUST,74.8,56
-Wendy's,Food & Beverage,ETHICS,76.8,44
-Wendy's,Food & Beverage,GROWTH,75.3,66
-Wendy's,Food & Beverage,P&S,73.5,74
-Wendy's,Food & Beverage,CITIZENSHIP,73.5,36
-Wendy's,Food & Beverage,VISION,77.8,53
-Wendy's,Food & Beverage,CULTURE,73.4,62
-The Walt Disney Company,Media,TRUST,59.6,96
-The Walt Disney Company,Media,ETHICS,60.8,95
-The Walt Disney Company,Media,GROWTH,69.5,91
-The Walt Disney Company,Media,P&S,67.2,92
-The Walt Disney Company,Media,CITIZENSHIP,61.2,95
-The Walt Disney Company,Media,VISION,68.6,94
-The Walt Disney Company,Media,CULTURE,64.9,93
-Delta Air Lines,Airline,TRUST,74.7,57
+Macy's,Retail,TRUST,74.11,60
+Macy's,Retail,ETHICS,73.84,62
+Macy's,Retail,GROWTH,73.11,79
+Macy's,Retail,P&S,76.06,63
+Macy's,Retail,CITIZENSHIP,71.57,54
+Macy's,Retail,VISION,74.43,75
+Macy's,Retail,CULTURE,72.64,68
+Wendy's,Food & Beverage,TRUST,74.77,56
+Wendy's,Food & Beverage,ETHICS,76.77,44
+Wendy's,Food & Beverage,GROWTH,75.3,68
+Wendy's,Food & Beverage,P&S,73.53,74
+Wendy's,Food & Beverage,CITIZENSHIP,73.52,34
+Wendy's,Food & Beverage,VISION,77.75,53
+Wendy's,Food & Beverage,CULTURE,73.37,61
+The Walt Disney Company,Media,TRUST,70.52,80
+The Walt Disney Company,Media,ETHICS,71.4,72
+The Walt Disney Company,Media,GROWTH,77.68,52
+The Walt Disney Company,Media,P&S,78.28,44
+The Walt Disney Company,Media,CITIZENSHIP,70.75,62
+The Walt Disney Company,Media,VISION,76.87,58
+The Walt Disney Company,Media,CULTURE,71.89,71
+Delta Air Lines,Airline,TRUST,74.65,58
 Delta Air Lines,Airline,ETHICS,72.2,65
-Delta Air Lines,Airline,GROWTH,76,61
-Delta Air Lines,Airline,P&S,73.9,70
-Delta Air Lines,Airline,CITIZENSHIP,71,61
-Delta Air Lines,Airline,VISION,73.5,81
-Delta Air Lines,Airline,CULTURE,75.1,55
-Verizon Communications,Telecom,TRUST,72,70
-Verizon Communications,Telecom,ETHICS,71.5,70
-Verizon Communications,Telecom,GROWTH,75.3,69
-Verizon Communications,Telecom,P&S,76.1,62
-Verizon Communications,Telecom,CITIZENSHIP,66.9,82
-Verizon Communications,Telecom,VISION,76.3,59
-Verizon Communications,Telecom,CULTURE,72.4,69
+Delta Air Lines,Airline,GROWTH,76.04,61
+Delta Air Lines,Airline,P&S,73.86,70
+Delta Air Lines,Airline,CITIZENSHIP,71.01,61
+Delta Air Lines,Airline,VISION,73.52,81
+Delta Air Lines,Airline,CULTURE,75.07,55
+Verizon Communications,Telecom,TRUST,71.98,71
+Verizon Communications,Telecom,ETHICS,71.51,70
+Verizon Communications,Telecom,GROWTH,75.32,66
+Verizon Communications,Telecom,P&S,76.1,60
+Verizon Communications,Telecom,CITIZENSHIP,66.91,82
+Verizon Communications,Telecom,VISION,76.31,59
+Verizon Communications,Telecom,CULTURE,72.4,70
 DoorDash,Food Delivery,TRUST,71.9,73
-DoorDash,Food Delivery,ETHICS,74.6,60
-DoorDash,Food Delivery,GROWTH,75.9,62
-DoorDash,Food Delivery,P&S,74.1,69
+DoorDash,Food Delivery,ETHICS,74.63,59
+DoorDash,Food Delivery,GROWTH,75.92,62
+DoorDash,Food Delivery,P&S,74.13,69
 DoorDash,Food Delivery,CITIZENSHIP,71.3,57
-DoorDash,Food Delivery,VISION,75.2,69
-DoorDash,Food Delivery,CULTURE,73.2,64
-"Electronic Arts, Inc.",Tech,TRUST,71.4,76
-"Electronic Arts, Inc.",Tech,ETHICS,71.3,73
-"Electronic Arts, Inc.",Tech,GROWTH,73.8,73
-"Electronic Arts, Inc.",Tech,P&S,75.4,66
+DoorDash,Food Delivery,VISION,75.22,69
+DoorDash,Food Delivery,CULTURE,73.24,64
+"Electronic Arts, Inc.",Tech,TRUST,71.38,76
+"Electronic Arts, Inc.",Tech,ETHICS,71.26,73
+"Electronic Arts, Inc.",Tech,GROWTH,73.82,73
+"Electronic Arts, Inc.",Tech,P&S,75.37,66
 "Electronic Arts, Inc.",Tech,CITIZENSHIP,69.8,69
-"Electronic Arts, Inc.",Tech,VISION,73.6,80
-"Electronic Arts, Inc.",Tech,CULTURE,70.8,75
-Chipotle,Food & Beverage,TRUST,71.3,77
-Chipotle,Food & Beverage,ETHICS,72.1,67
-Chipotle,Food & Beverage,GROWTH,75.4,65
-Chipotle,Food & Beverage,P&S,73.3,75
-Chipotle,Food & Beverage,CITIZENSHIP,69.5,73
-Chipotle,Food & Beverage,VISION,73,84
-Chipotle,Food & Beverage,CULTURE,70,77
-AT&T,Telecom,TRUST,72.1,68
-AT&T,Telecom,ETHICS,70.6,76
-AT&T,Telecom,GROWTH,73.2,78
-AT&T,Telecom,P&S,74.7,68
-AT&T,Telecom,CITIZENSHIP,69.5,72
-AT&T,Telecom,VISION,74.8,72
+"Electronic Arts, Inc.",Tech,VISION,73.61,80
+"Electronic Arts, Inc.",Tech,CULTURE,70.81,75
+Chipotle,Food & Beverage,TRUST,71.27,78
+Chipotle,Food & Beverage,ETHICS,72.08,67
+Chipotle,Food & Beverage,GROWTH,75.38,65
+Chipotle,Food & Beverage,P&S,73.34,75
+Chipotle,Food & Beverage,CITIZENSHIP,69.51,73
+Chipotle,Food & Beverage,VISION,72.97,84
+Chipotle,Food & Beverage,CULTURE,70,78
+AT&T,Telecom,TRUST,72.05,69
+AT&T,Telecom,ETHICS,70.57,77
+AT&T,Telecom,GROWTH,73.15,78
+AT&T,Telecom,P&S,74.74,67
+AT&T,Telecom,CITIZENSHIP,69.52,72
+AT&T,Telecom,VISION,74.77,73
 AT&T,Telecom,CULTURE,71.6,73
 Johnson & Johnson,Pharma,TRUST,70.1,81
-Johnson & Johnson,Pharma,ETHICS,71.4,72
-Johnson & Johnson,Pharma,GROWTH,74.5,70
-Johnson & Johnson,Pharma,P&S,75.9,65
-Johnson & Johnson,Pharma,CITIZENSHIP,68,77
-Johnson & Johnson,Pharma,VISION,74.8,73
-Johnson & Johnson,Pharma,CULTURE,73.3,63
-Robinhood,Tech,TRUST,71.3,78
-Robinhood,Tech,ETHICS,69.7,81
+Johnson & Johnson,Pharma,ETHICS,71.43,71
+Johnson & Johnson,Pharma,GROWTH,74.49,70
+Johnson & Johnson,Pharma,P&S,75.89,65
+Johnson & Johnson,Pharma,CITIZENSHIP,67.98,77
+Johnson & Johnson,Pharma,VISION,74.79,71
+Johnson & Johnson,Pharma,CULTURE,73.27,63
+Robinhood,Tech,TRUST,71.31,77
+Robinhood,Tech,ETHICS,69.65,82
 Robinhood,Tech,GROWTH,73.8,74
-Robinhood,Tech,P&S,73.6,73
-Robinhood,Tech,CITIZENSHIP,69.7,71
-Robinhood,Tech,VISION,74,78
-Robinhood,Tech,CULTURE,71.4,74
-Dollar Tree,Retail,TRUST,75.9,47
-Dollar Tree,Retail,ETHICS,72.7,63
+Robinhood,Tech,P&S,73.59,73
+Robinhood,Tech,CITIZENSHIP,69.65,71
+Robinhood,Tech,VISION,73.99,78
+Robinhood,Tech,CULTURE,71.35,74
+Dollar Tree,Retail,TRUST,75.87,47
+Dollar Tree,Retail,ETHICS,72.65,63
 Dollar Tree,Retail,GROWTH,73.6,76
-Dollar Tree,Retail,P&S,67,93
-Dollar Tree,Retail,CITIZENSHIP,71.3,58
-Dollar Tree,Retail,VISION,76,62
-Dollar Tree,Retail,CULTURE,69.3,82
-Grubhub Inc.,Food Delivery,TRUST,70.9,79
-Grubhub Inc.,Food Delivery,ETHICS,70.5,78
-Grubhub Inc.,Food Delivery,GROWTH,74.4,71
-Grubhub Inc.,Food Delivery,P&S,72.8,76
-Grubhub Inc.,Food Delivery,CITIZENSHIP,67.8,78
-Grubhub Inc.,Food Delivery,VISION,75.5,65
-Grubhub Inc.,Food Delivery,CULTURE,69.6,80
-Big Lots,Retail,TRUST,76.6,36
+Dollar Tree,Retail,P&S,66.97,93
+Dollar Tree,Retail,CITIZENSHIP,71.25,58
+Dollar Tree,Retail,VISION,75.97,62
+Dollar Tree,Retail,CULTURE,69.29,83
+Grubhub Inc.,Food Delivery,TRUST,70.94,79
+Grubhub Inc.,Food Delivery,ETHICS,70.54,78
+Grubhub Inc.,Food Delivery,GROWTH,74.41,71
+Grubhub Inc.,Food Delivery,P&S,72.79,76
+Grubhub Inc.,Food Delivery,CITIZENSHIP,67.81,78
+Grubhub Inc.,Food Delivery,VISION,75.48,65
+Grubhub Inc.,Food Delivery,CULTURE,69.64,80
+Big Lots,Retail,TRUST,76.59,37
 Big Lots,Retail,ETHICS,74.4,61
-Big Lots,Retail,GROWTH,70.9,88
-Big Lots,Retail,P&S,68.1,91
-Big Lots,Retail,CITIZENSHIP,70,68
-Big Lots,Retail,VISION,74.1,77
-Big Lots,Retail,CULTURE,70.6,76
-Walmart,Retail,TRUST,72,71
-Walmart,Retail,ETHICS,68.8,85
-Walmart,Retail,GROWTH,76.9,59
-Walmart,Retail,P&S,71.5,83
-Walmart,Retail,CITIZENSHIP,67.6,80
-Walmart,Retail,VISION,76.1,60
-Walmart,Retail,CULTURE,67.4,87
-Shein,Retail,TRUST,71.8,74
-Shein,Retail,ETHICS,69.3,83
-Shein,Retail,GROWTH,75.9,63
-Shein,Retail,P&S,70,87
-Shein,Retail,CITIZENSHIP,68.1,76
-Shein,Retail,VISION,75.1,70
-Shein,Retail,CULTURE,69.3,83
-Bank of America,Financial Services,TRUST,68.6,86
-Bank of America,Financial Services,ETHICS,70.5,79
-Bank of America,Financial Services,GROWTH,72.6,82
-Bank of America,Financial Services,P&S,72.1,78
-Bank of America,Financial Services,CITIZENSHIP,66.4,84
-Bank of America,Financial Services,VISION,74.7,74
-Bank of America,Financial Services,CULTURE,72.4,70
-Goldman Sachs,Financial Services,TRUST,67.4,88
-Goldman Sachs,Financial Services,ETHICS,69,84
-Goldman Sachs,Financial Services,GROWTH,76.2,60
-Goldman Sachs,Financial Services,P&S,74.7,67
-Goldman Sachs,Financial Services,CITIZENSHIP,66.2,85
+Big Lots,Retail,GROWTH,70.87,88
+Big Lots,Retail,P&S,68.08,91
+Big Lots,Retail,CITIZENSHIP,69.98,68
+Big Lots,Retail,VISION,74.08,77
+Big Lots,Retail,CULTURE,70.58,76
+Walmart,Retail,TRUST,72.04,70
+Walmart,Retail,ETHICS,68.75,85
+Walmart,Retail,GROWTH,76.91,59
+Walmart,Retail,P&S,71.47,83
+Walmart,Retail,CITIZENSHIP,67.57,80
+Walmart,Retail,VISION,76.14,60
+Walmart,Retail,CULTURE,67.36,87
+Shein,Retail,TRUST,71.83,74
+Shein,Retail,ETHICS,69.26,83
+Shein,Retail,GROWTH,75.86,63
+Shein,Retail,P&S,69.95,87
+Shein,Retail,CITIZENSHIP,68.14,76
+Shein,Retail,VISION,75.08,70
+Shein,Retail,CULTURE,69.32,82
+Bank of America,Financial Services,TRUST,68.57,86
+Bank of America,Financial Services,ETHICS,70.46,79
+Bank of America,Financial Services,GROWTH,72.63,82
+Bank of America,Financial Services,P&S,72.1,77
+Bank of America,Financial Services,CITIZENSHIP,66.37,84
+Bank of America,Financial Services,VISION,74.72,74
+Bank of America,Financial Services,CULTURE,72.43,69
+Goldman Sachs,Financial Services,TRUST,67.35,88
+Goldman Sachs,Financial Services,ETHICS,69.01,84
+Goldman Sachs,Financial Services,GROWTH,76.22,60
+Goldman Sachs,Financial Services,P&S,74.65,68
+Goldman Sachs,Financial Services,CITIZENSHIP,66.15,85
 Goldman Sachs,Financial Services,VISION,75.4,66
-Goldman Sachs,Financial Services,CULTURE,73,65
-Burger King,Food & Beverage,TRUST,72.1,69
-Burger King,Food & Beverage,ETHICS,70.6,77
-Burger King,Food & Beverage,GROWTH,72,84
-Burger King,Food & Beverage,P&S,71.7,81
+Goldman Sachs,Financial Services,CULTURE,72.97,65
+Burger King,Food & Beverage,TRUST,72.12,68
+Burger King,Food & Beverage,ETHICS,70.58,76
+Burger King,Food & Beverage,GROWTH,71.96,84
+Burger King,Food & Beverage,P&S,71.66,81
 Burger King,Food & Beverage,CITIZENSHIP,69.5,74
-Burger King,Food & Beverage,VISION,73.8,79
-Burger King,Food & Beverage,CULTURE,67.3,88
-Spectrum,Telecom,TRUST,68.8,85
-Spectrum,Telecom,ETHICS,69.7,82
-Spectrum,Telecom,GROWTH,73,80
-Spectrum,Telecom,P&S,72.1,77
-Spectrum,Telecom,CITIZENSHIP,66.4,83
-Spectrum,Telecom,VISION,76.1,61
-Spectrum,Telecom,CULTURE,71.8,72
-eBay,Ecommerce,TRUST,71.7,75
-eBay,Ecommerce,ETHICS,67.5,87
+Burger King,Food & Beverage,VISION,73.83,79
+Burger King,Food & Beverage,CULTURE,67.28,88
+Spectrum,Telecom,TRUST,68.75,85
+Spectrum,Telecom,ETHICS,69.68,81
+Spectrum,Telecom,GROWTH,72.98,80
+Spectrum,Telecom,P&S,72.09,78
+Spectrum,Telecom,CITIZENSHIP,66.44,83
+Spectrum,Telecom,VISION,76.05,61
+Spectrum,Telecom,CULTURE,71.79,72
+eBay,Ecommerce,TRUST,71.73,75
+eBay,Ecommerce,ETHICS,67.49,87
 eBay,Ecommerce,GROWTH,71.6,85
-eBay,Ecommerce,P&S,70.1,86
-eBay,Ecommerce,CITIZENSHIP,67.3,81
-eBay,Ecommerce,VISION,72,87
-eBay,Ecommerce,CULTURE,69.7,79
-Subway,Food & Beverage,TRUST,69.7,83
-Subway,Food & Beverage,ETHICS,71.7,69
-Subway,Food & Beverage,GROWTH,72.2,83
-Subway,Food & Beverage,P&S,71.9,80
-Subway,Food & Beverage,CITIZENSHIP,65.7,86
-Subway,Food & Beverage,VISION,73.4,83
-Subway,Food & Beverage,CULTURE,68.7,85
-Comcast,Media,TRUST,66.6,90
-Comcast,Media,ETHICS,67.8,86
-Comcast,Media,GROWTH,72.9,81
-Comcast,Media,P&S,72,79
-Comcast,Media,CITIZENSHIP,65.2,88
-Comcast,Media,VISION,72.6,85
-Comcast,Media,CULTURE,69.6,81
+eBay,Ecommerce,P&S,70.07,86
+eBay,Ecommerce,CITIZENSHIP,67.34,81
+eBay,Ecommerce,VISION,72.01,87
+eBay,Ecommerce,CULTURE,69.69,79
+Subway,Food & Beverage,TRUST,69.69,83
+Subway,Food & Beverage,ETHICS,71.66,69
+Subway,Food & Beverage,GROWTH,72.15,83
+Subway,Food & Beverage,P&S,71.91,80
+Subway,Food & Beverage,CITIZENSHIP,65.69,86
+Subway,Food & Beverage,VISION,73.36,83
+Subway,Food & Beverage,CULTURE,68.72,85
+Comcast,Media,TRUST,66.63,90
+Comcast,Media,ETHICS,67.83,86
+Comcast,Media,GROWTH,72.86,81
+Comcast,Media,P&S,71.96,79
+Comcast,Media,CITIZENSHIP,65.19,88
+Comcast,Media,VISION,72.55,86
+Comcast,Media,CULTURE,69.61,81
 McDonald's,Food & Beverage,TRUST,69.9,82
 McDonald's,Food & Beverage,ETHICS,70.3,80
 McDonald's,Food & Beverage,GROWTH,74.1,72
@@ -601,101 +601,101 @@ McDonald's,Food & Beverage,P&S,68.7,90
 McDonald's,Food & Beverage,CITIZENSHIP,70,67
 McDonald's,Food & Beverage,VISION,73.5,82
 McDonald's,Food & Beverage,CULTURE,66.3,91
-JCPenney,Retail,TRUST,73,64
-JCPenney,Retail,ETHICS,72.3,64
-JCPenney,Retail,GROWTH,62.3,98
-JCPenney,Retail,P&S,69.8,88
-JCPenney,Retail,CITIZENSHIP,68.7,75
-JCPenney,Retail,VISION,66.8,95
-JCPenney,Retail,CULTURE,69.2,84
-ExxonMobil,Energy,TRUST,66.2,92
-ExxonMobil,Energy,ETHICS,65.9,91
-ExxonMobil,Energy,GROWTH,71.3,86
-ExxonMobil,Energy,P&S,73.7,72
-ExxonMobil,Energy,CITIZENSHIP,61.8,94
-ExxonMobil,Energy,VISION,71.1,89
-ExxonMobil,Energy,CULTURE,70,78
-BP,Energy,TRUST,66.3,91
-BP,Energy,ETHICS,66.6,89
-BP,Energy,GROWTH,71.2,87
+JCPenney,Retail,TRUST,72.99,64
+JCPenney,Retail,ETHICS,72.28,64
+JCPenney,Retail,GROWTH,62.28,98
+JCPenney,Retail,P&S,69.79,88
+JCPenney,Retail,CITIZENSHIP,68.66,75
+JCPenney,Retail,VISION,66.76,95
+JCPenney,Retail,CULTURE,69.23,84
+ExxonMobil,Energy,TRUST,66.23,92
+ExxonMobil,Energy,ETHICS,65.85,91
+ExxonMobil,Energy,GROWTH,71.26,86
+ExxonMobil,Energy,P&S,73.72,72
+ExxonMobil,Energy,CITIZENSHIP,61.82,94
+ExxonMobil,Energy,VISION,71.05,89
+ExxonMobil,Energy,CULTURE,70.04,77
+BP,Energy,TRUST,66.34,91
+BP,Energy,ETHICS,66.57,89
+BP,Energy,GROWTH,71.21,87
 BP,Energy,P&S,71.1,84
-BP,Energy,CITIZENSHIP,62.8,91
-BP,Energy,VISION,71.1,88
-BP,Energy,CULTURE,68.5,86
-My Pillow,Ecommerce,TRUST,69,84
-My Pillow,Ecommerce,ETHICS,66.4,90
-My Pillow,Ecommerce,GROWTH,66.5,94
-My Pillow,Ecommerce,P&S,71.6,82
-My Pillow,Ecommerce,CITIZENSHIP,64.6,89
-My Pillow,Ecommerce,VISION,70.4,91
-My Pillow,Ecommerce,CULTURE,66.6,90
-Uber,Tech,TRUST,67.8,87
-Uber,Tech,ETHICS,67.1,88
+BP,Energy,CITIZENSHIP,62.83,91
+BP,Energy,VISION,71.11,88
+BP,Energy,CULTURE,68.54,86
+My Pillow,Ecommerce,TRUST,68.99,84
+My Pillow,Ecommerce,ETHICS,66.41,90
+My Pillow,Ecommerce,GROWTH,66.46,94
+My Pillow,Ecommerce,P&S,71.62,82
+My Pillow,Ecommerce,CITIZENSHIP,64.58,89
+My Pillow,Ecommerce,VISION,70.36,91
+My Pillow,Ecommerce,CULTURE,66.57,90
+Uber,Tech,TRUST,67.82,87
+Uber,Tech,ETHICS,67.12,88
 Uber,Tech,GROWTH,70.7,89
-Uber,Tech,P&S,70.4,85
-Uber,Tech,CITIZENSHIP,63.5,90
-Uber,Tech,VISION,70.6,90
+Uber,Tech,P&S,70.41,85
+Uber,Tech,CITIZENSHIP,63.53,90
+Uber,Tech,VISION,70.58,90
 Uber,Tech,CULTURE,65,92
-Wells Fargo & Company,Financial Services,TRUST,65.3,93
-Wells Fargo & Company,Financial Services,ETHICS,64.6,94
-Wells Fargo & Company,Financial Services,GROWTH,70.6,90
-Wells Fargo & Company,Financial Services,P&S,69.4,89
-Wells Fargo & Company,Financial Services,CITIZENSHIP,62.1,93
-Wells Fargo & Company,Financial Services,VISION,72.6,86
-Wells Fargo & Company,Financial Services,CULTURE,67,89
-Sears Holdings Corporation,Retail,TRUST,66.9,89
-Sears Holdings Corporation,Retail,ETHICS,65.7,92
-Sears Holdings Corporation,Retail,GROWTH,57.9,99
-Sears Holdings Corporation,Retail,P&S,66.8,94
-Sears Holdings Corporation,Retail,CITIZENSHIP,65.5,87
-Sears Holdings Corporation,Retail,VISION,61.9,99
-Sears Holdings Corporation,Retail,CULTURE,60.7,97
-TikTok,Tech,TRUST,73.5,62
-TikTok,Tech,ETHICS,76.9,42
-TikTok,Tech,GROWTH,80,36
-TikTok,Tech,P&S,77.9,52
-TikTok,Tech,CITIZENSHIP,72.5,46
-TikTok,Tech,VISION,80.7,24
-TikTok,Tech,CULTURE,76.3,48
-Spirit Airlines,Airline,TRUST,63.2,94
-Spirit Airlines,Airline,ETHICS,65,93
-Spirit Airlines,Airline,GROWTH,67.8,93
-Spirit Airlines,Airline,P&S,62,97
-Spirit Airlines,Airline,CITIZENSHIP,62.7,92
-Spirit Airlines,Airline,VISION,69.2,93
+Wells Fargo & Company,Financial Services,TRUST,65.28,93
+Wells Fargo & Company,Financial Services,ETHICS,64.62,94
+Wells Fargo & Company,Financial Services,GROWTH,70.58,90
+Wells Fargo & Company,Financial Services,P&S,69.37,89
+Wells Fargo & Company,Financial Services,CITIZENSHIP,62.12,93
+Wells Fargo & Company,Financial Services,VISION,72.57,85
+Wells Fargo & Company,Financial Services,CULTURE,66.99,89
+Sears Holdings Corporation,Retail,TRUST,66.86,89
+Sears Holdings Corporation,Retail,ETHICS,65.68,92
+Sears Holdings Corporation,Retail,GROWTH,57.86,99
+Sears Holdings Corporation,Retail,P&S,66.78,94
+Sears Holdings Corporation,Retail,CITIZENSHIP,65.52,87
+Sears Holdings Corporation,Retail,VISION,61.88,99
+Sears Holdings Corporation,Retail,CULTURE,60.66,97
+TikTok,Tech,TRUST,59.6,96
+TikTok,Tech,ETHICS,60.8,95
+TikTok,Tech,GROWTH,69.5,91
+TikTok,Tech,P&S,67.2,92
+TikTok,Tech,CITIZENSHIP,61.2,95
+TikTok,Tech,VISION,68.6,94
+TikTok,Tech,CULTURE,64.9,93
+Spirit Airlines,Airline,TRUST,63.21,94
+Spirit Airlines,Airline,ETHICS,64.97,93
+Spirit Airlines,Airline,GROWTH,67.79,93
+Spirit Airlines,Airline,P&S,62.01,97
+Spirit Airlines,Airline,CITIZENSHIP,62.73,92
+Spirit Airlines,Airline,VISION,69.16,93
 Spirit Airlines,Airline,CULTURE,64.2,94
-Fox Corporation,Media,TRUST,59.2,97
-Fox Corporation,Media,ETHICS,60.2,97
-Fox Corporation,Media,GROWTH,65.9,95
-Fox Corporation,Media,P&S,63.4,96
-Fox Corporation,Media,CITIZENSHIP,60.2,97
-Fox Corporation,Media,VISION,66.3,96
-Fox Corporation,Media,CULTURE,59.9,98
-Facebook,Tech,TRUST,55.8,99
-Facebook,Tech,ETHICS,57.4,98
-Facebook,Tech,GROWTH,68.1,92
-Facebook,Tech,P&S,64.8,95
-Facebook,Tech,CITIZENSHIP,57.4,98
-Facebook,Tech,VISION,69.5,92
-Facebook,Tech,CULTURE,62.1,95
-Twitter,Tech,TRUST,57.3,98
+Fox Corporation,Media,TRUST,59.19,97
+Fox Corporation,Media,ETHICS,60.17,97
+Fox Corporation,Media,GROWTH,65.89,95
+Fox Corporation,Media,P&S,63.37,96
+Fox Corporation,Media,CITIZENSHIP,60.21,97
+Fox Corporation,Media,VISION,66.32,96
+Fox Corporation,Media,CULTURE,59.88,98
+Facebook,Tech,TRUST,55.83,99
+Facebook,Tech,ETHICS,57.44,98
+Facebook,Tech,GROWTH,68.13,92
+Facebook,Tech,P&S,64.76,95
+Facebook,Tech,CITIZENSHIP,57.42,98
+Facebook,Tech,VISION,69.49,92
+Facebook,Tech,CULTURE,62.09,95
+Twitter,Tech,TRUST,57.31,98
 Twitter,Tech,ETHICS,56.9,99
-Twitter,Tech,GROWTH,64.9,97
-Twitter,Tech,P&S,61.6,98
-Twitter,Tech,CITIZENSHIP,57.4,99
-Twitter,Tech,VISION,66.1,97
-Twitter,Tech,CULTURE,59.6,99
-Wish.com,Ecommerce,TRUST,62.4,95
-Wish.com,Ecommerce,ETHICS,60.7,96
-Wish.com,Ecommerce,GROWTH,65.6,96
-Wish.com,Ecommerce,P&S,58.1,99
+Twitter,Tech,GROWTH,64.92,97
+Twitter,Tech,P&S,61.63,98
+Twitter,Tech,CITIZENSHIP,57.35,99
+Twitter,Tech,VISION,66.11,97
+Twitter,Tech,CULTURE,59.64,99
+Wish.com,Ecommerce,TRUST,62.36,95
+Wish.com,Ecommerce,ETHICS,60.73,96
+Wish.com,Ecommerce,GROWTH,65.57,96
+Wish.com,Ecommerce,P&S,58.08,99
 Wish.com,Ecommerce,CITIZENSHIP,61.1,96
-Wish.com,Ecommerce,VISION,64.2,98
+Wish.com,Ecommerce,VISION,64.24,98
 Wish.com,Ecommerce,CULTURE,62,96
-The Trump Organization,Other,TRUST,70.5,80
-The Trump Organization,Other,ETHICS,71.4,71
-The Trump Organization,Other,GROWTH,77.7,52
-The Trump Organization,Other,P&S,78.3,45
-The Trump Organization,Other,CITIZENSHIP,70.8,62
-The Trump Organization,Other,VISION,76.9,57
-The Trump Organization,Other,CULTURE,71.9,71
+The Trump Organization,Other,TRUST,52.92,100
+The Trump Organization,Other,ETHICS,51.24,100
+The Trump Organization,Other,GROWTH,55.13,100
+The Trump Organization,Other,P&S,55.67,100
+The Trump Organization,Other,CITIZENSHIP,53.57,100
+The Trump Organization,Other,VISION,59.38,100
+The Trump Organization,Other,CULTURE,52.96,100


### PR DESCRIPTION
There seems to be some discrepancy between the Axios/Harris numbers and the ones in this repo. The Trump Org numbers in [data/2022/2022-05-31/reputation.csv](https://github.com/rfordatascience/tidytuesday/pull/442/files/3643580c6b4621eb56f6ec622ca43242d7f51a4a#diff-db694ac0875faa3940ddb2bb63042141327e09360591ef238533757389fb87f4) seem to be a particularly stark difference. 

I've rerun the script in README using a JS link I found in the HTML source. 