### PR TITLE
Correct typo CMEAD -> CMED

### DIFF
--- a/data/2021/2021-08-24/readme.md
+++ b/data/2021/2021-08-24/readme.md
@@ -87,7 +87,7 @@ Mostipak](https://github.com/rfordatascience/tidytuesday/issues/204).
 
 | **Taxon** | **Latin name**               | **Common name**              |
 |:----------|:-----------------------------|:-----------------------------|
-| CMEAD     | Cheirogaleus medius          | Fat-tailed dwarf lemur       |
+| CMED     | Cheirogaleus medius          | Fat-tailed dwarf lemur       |
 | DMAD      | Daubentonia madagascariensis | Aye-aye                      |
 | EALB      | Eulemur albifrons            | White-fronted brown lemur    |
 | ECOL      | Eulemur collaris             | Collared brown lemur         |

--- a/data/2021/2021-08-24/readme.md
+++ b/data/2021/2021-08-24/readme.md
@@ -87,7 +87,7 @@ Mostipak](https://github.com/rfordatascience/tidytuesday/issues/204).
 
 | **Taxon** | **Latin name**               | **Common name**              |
 |:----------|:-----------------------------|:-----------------------------|
-| CMED     | Cheirogaleus medius          | Fat-tailed dwarf lemur       |
+| CMED      | Cheirogaleus medius           | Fat-tailed dwarf lemur       |
 | DMAD      | Daubentonia madagascariensis | Aye-aye                      |
 | EALB      | Eulemur albifrons            | White-fronted brown lemur    |
 | ECOL      | Eulemur collaris             | Collared brown lemur         |


### PR DESCRIPTION
taxon code for the fat-tailed dwarf lemur is listed incorrectly as "CMEAD", it is actually "CMED" in the dataset