### PR TITLE
Fix two broken URLs to US Census Bureau website

### DIFF
--- a/data/2022/2022-12-13/README.md
+++ b/data/2022/2022-12-13/README.md
@@ -65,9 +65,9 @@ coverage_codes <- readr::read_csv('https://raw.githubusercontent.com/rfordatasci
 
 |variable      |class     |description   |
 |:-------------|:---------|:-------------|
-|fips          |character |2-digit State Federal Information Processing Standards (FIPS) code. For more information on FIPS Codes, please reference [this document](https://www.census.gov/library/reference/codelists/ansi/ansi-codes-for-states.html). Note: The US is assigned a "00"" State FIPS code|
+|fips          |character |2-digit State Federal Information Processing Standards (FIPS) code. For more information on FIPS Codes, please reference [this document](https://www.census.gov/library/reference/code-lists/ansi/ansi-codes-for-states.html). Note: The US is assigned a "00"" State FIPS code|
 |state_abbr    |character |States are assigned 2-character official U.S. Postal
-Service Code. The United States is assigned "USA" as its state_abbr value. For more information, please reference [this document](https://www.census.gov/library/reference/codelists/ansi/ansi-codes-for-states.html).|
+Service Code. The United States is assigned "USA" as its state_abbr value. For more information, please reference [this document](https://www.census.gov/library/reference/code-lists/ansi/ansi-codes-for-states.html).|
 |naics         |integer   |Three-digit numeric NAICS value for retail subsector
 code|
 |subsector     |character |Retail subsector.|


### PR DESCRIPTION
Existing URLs in guidance on ANSI codes return 404 error. Looks like a hyphen in URL was omitted (codelists, instead of code-lists). Adding it back in to returns 200 (https://www.census.gov/library/reference/code-lists/ansi/ansi-codes-for-states.html).