### PR TITLE
Updated wcmatches.csv

### DIFF
--- a/data/2022/2022-11-29/wcmatches.csv
+++ b/data/2022/2022-11-29/wcmatches.csv
@@ -32,7 +32,7 @@ year,country,city,stage,home_team,away_team,home_score,away_score,outcome,win_co
 1934,Italy,Florence,Quarterfinals,Italy,Spain,1,0,H,,Italy,Spain,1934-06-01,Jun,Friday
 1934,Italy,Rome,Semifinals,Czechoslovakia,Germany,3,1,H,,Czechoslovakia,Germany,1934-06-03,Jun,Sunday
 1934,Italy,Milan,Semifinals,Italy,Austria,1,0,H,,Italy,Austria,1934-06-03,Jun,Sunday
-1934,Italy,Naples,Third place,Austria,Germany,2,3,A,,West Germany,Austria,1934-06-07,Jun,Thursday
+1934,Italy,Naples,Third place,Austria,Germany,2,3,A,,Germany,Austria,1934-06-07,Jun,Thursday
 1934,Italy,Rome,Final,Italy,Czechoslovakia,2,1,H,Italy won in AET,Italy,Czechoslovakia,1934-06-10,Jun,Sunday
 1938,France,Paris,Round of 16,Germany,Switzerland,1,1,D,,NA,NA,1938-06-04,Jun,Saturday
 1938,France,Strasbourg,Round of 16,Brazil,Poland,6,5,H,Brazil won in AET,Brazil,Poland,1938-06-05,Jun,Sunday


### PR DESCRIPTION
Changed the winning_team value in row 35 from "West Germany" to "Germany". I think this was a typo as the away_team value is set to "Germany" and West Germany was not a country in 1934.