### PR TITLE
Updated typo in wcmatches.csv

### DIFF
--- a/data/2022/2022-11-29/wcmatches.csv
+++ b/data/2022/2022-11-29/wcmatches.csv
@@ -32,7 +32,7 @@ year,country,city,stage,home_team,away_team,home_score,away_score,outcome,win_co
 1934,Italy,Florence,Quarterfinals,Italy,Spain,1,0,H,,Italy,Spain,1934-06-01,Jun,Friday
 1934,Italy,Rome,Semifinals,Czechoslovakia,Germany,3,1,H,,Czechoslovakia,Germany,1934-06-03,Jun,Sunday
 1934,Italy,Milan,Semifinals,Italy,Austria,1,0,H,,Italy,Austria,1934-06-03,Jun,Sunday
-1934,Italy,Naples,Third place,Austria,Germany,2,3,A,,West Germany,Austria,1934-06-07,Jun,Thursday
+1934,Italy,Naples,Third place,Austria,Germany,2,3,A,,Germany,Austria,1934-06-07,Jun,Thursday
 1934,Italy,Rome,Final,Italy,Czechoslovakia,2,1,H,Italy won in AET,Italy,Czechoslovakia,1934-06-10,Jun,Sunday
 1938,France,Paris,Round of 16,Germany,Switzerland,1,1,D,,NA,NA,1938-06-04,Jun,Saturday
 1938,France,Strasbourg,Round of 16,Brazil,Poland,6,5,H,Brazil won in AET,Brazil,Poland,1938-06-05,Jun,Sunday

--- a/data/2022/2022-11-29/wcmatches.csv
+++ b/data/2022/2022-11-29/wcmatches.csv
@@ -260,7 +260,7 @@ year,country,city,stage,home_team,away_team,home_score,away_score,outcome,win_co
 1974,Germany,Gelsenkirchen,Group A,Netherlands,Argentina,4,0,H,,Netherlands,Argentina,1974-06-26,Jun,Wednesday
 1974,Germany,Stuttgart,Group B,Sweden,Poland,0,1,A,,Poland,Sweden,1974-06-26,Jun,Wednesday
 1974,Germany,Hanover,Group A,Argentina,Brazil,1,2,A,,Brazil,Argentina,1974-06-30,Jun,Sunday
-1974,Germany,Gelsenkirchen,Group A,East Germany,Netherlands,0,2,A,,Netherlands,West Germany,1974-06-30,Jun,Sunday
+1974,Germany,Gelsenkirchen,Group A,East Germany,Netherlands,0,2,A,,Netherlands,East Germany,1974-06-30,Jun,Sunday
 1974,Germany,Düsseldorf,Group B,West Germany,Sweden,4,2,H,,West Germany,Sweden,1974-06-30,Jun,Sunday
 1974,Germany,Frankfurt am Main,Group B,Poland,Yugoslavia,2,1,H,,Poland,Yugoslavia,1974-06-30,Jun,Sunday
 1974,Germany,Gelsenkirchen,Group A,Argentina,East Germany,1,1,D,,NA,NA,1974-07-03,Jul,Wednesday


### PR DESCRIPTION
In row 263 of wcmatches.csv, home_team value is "East Germany" so I changed losing_team value from "West Germany" to "East Germany". I also made sure to verify that East Germany was playing in this match rather than West Germany.