### PR TITLE
update 2023-04-11 README to fix tidytuesdayR data name

### DIFF
--- a/data/2023/2023-04-11/readme.md
+++ b/data/2023/2023-04-11/readme.md
@@ -81,8 +81,8 @@ This dataset tracks the supply of cage-free eggs in the United States from Decem
 tuesdata <- tidytuesdayR::tt_load('2023-04-11')
 tuesdata <- tidytuesdayR::tt_load(2023, week = 15)
 
-eggproduction <- tuesdata$eggproduction
-cagefreepercentages <- tuesdata$cagefreepercentages
+eggproduction <- tuesdata$`egg-production`
+cagefreepercentages <- tuesdata$`cage-free-percentages`
 
 
 # Or read in the data manually


### PR DESCRIPTION
The code in the current version of the README does not work if you copy and paste it, because the two data sets have hyphens in their names in the `tidytuesdayR` list that gets downloaded. This PR updates the code so that it runs if it is copied and pasted.