### PR TITLE
Fix typo

### DIFF
--- a/data/2022/2022-06-07/readme.md
+++ b/data/2022/2022-06-07/readme.md
@@ -67,7 +67,7 @@ donors <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tid
 ### Data Dictionary
 
 # `pride_aggregates.csv`
-- Pride sponsors who have donated to Anti-LQBTQ Campaigns
+- Pride sponsors who have donated to Anti-LGBTQ Campaigns
 
 |variable                             |class     |description |
 |:------------------------------------|:---------|:-----------|
@@ -77,7 +77,7 @@ donors <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tid
 |# of States Where Contributions Made |double    |# of states where contributions were made to anti-LBGTQ    |
 
 # `fortune_aggregates.csv`
-- Fortune 500, Pride sponsors who have donated to Anti-LQBTQ Campaigns
+- Fortune 500, Pride sponsors who have donated to Anti-LGBTQ Campaigns
 
 |variable                             |class     |description |
 |:------------------------------------|:---------|:-----------|


### PR DESCRIPTION
I believe the following is a typo. This PR fixes it in two places.

LQBTQ -> LGBTQ