### PR TITLE
fix: Error in Lemur taxonomy mapping file

### DIFF
--- a/data/2021/2021-08-24/taxonomy.csv
+++ b/data/2021/2021-08-24/taxonomy.csv
@@ -1,5 +1,5 @@
 taxon,latin_name,common_name
-CMEAD,Cheirogaleus medius,Fat-tailed dwarf lemur
+CMED,Cheirogaleus medius,Fat-tailed dwarf lemur
 DMAD,Daubentonia madagascariensis,Aye-aye
 EALB,Eulemur albifrons,White-fronted brown lemur
 ECOL,Eulemur collaris,Collared brown lemur


### PR DESCRIPTION
The README and raw data reference CMED, but the mapping file contains CMEAD.