### PR TITLE
Remove .csv extension from week 7 data instructions

### DIFF
--- a/data/2024/2024-02-13/readme.md
+++ b/data/2024/2024-02-13/readme.md
@@ -18,11 +18,9 @@ tuesdata <- tidytuesdayR::tt_load('2024-02-13')
 ## OR
 tuesdata <- tidytuesdayR::tt_load(2024, week = 7)
 
-historical_spending <- tuesdata$historical_spending.csv
-gifts_age <- tuesdata$gifts_age.csv
-gifts_gender <- tuesdata$gifts_gender.csv
-
-
+historical_spending <- tuesdata$historical_spending
+gifts_age <- tuesdata$gifts_age
+gifts_gender <- tuesdata$gifts_gender
 
 
 # Option 2: Read directly from GitHub


### PR DESCRIPTION
The week 7 Valentine's Day comsumer data instructions for reading in the data with the tidytuesdayR package don't need file extensions.