### PR TITLE
[2024-03-12] Use correct separator

### DIFF
--- a/data/2024/2024-03-12/readme.md
+++ b/data/2024/2024-03-12/readme.md
@@ -69,7 +69,7 @@ fiscal_sponsor_directory |>
     dplyr::across(
       c(eligibility_criteria, project_types, services, fiscal_sponsorship_model),
       \(col) {
-        stringr::str_split(col, "\\n")
+        stringr::str_split(col, "\\|")
       }
     )
   )


### PR DESCRIPTION
I think the regex seperator for the `eligibility_criteria`, `project_types`, `services`, and `fiscal_sponsorship_model` columns is supposed to be `\\|` not `\\n`