### PR TITLE
Get rid of trailing spaces in yaml lines.

### DIFF
--- a/static/templates/metadata.R
+++ b/static/templates/metadata.R
@@ -5,6 +5,7 @@ read_metadata <- function(path) {
 
 yaml_preprocess <- function(path) {
   readLines(path, warn = FALSE) |> 
+    stringr::str_trim("right") |> 
     yaml_quote() |> 
     writeLines(path)
 }


### PR DESCRIPTION
Drop trailing spaces during metadata processing.