### PR TITLE
Adding python + posit references to templates

### DIFF
--- a/static/templates/how_to_participate.md
+++ b/static/templates/how_to_participate.md
@@ -1,6 +1,12 @@
 ## How to Participate
 
 - [Explore the data](https://r4ds.hadley.nz/), watching out for interesting relationships. We would like to emphasize that you should not draw conclusions about **causation** in the data. There are various moderating variables that affect all data, many of which might not have been captured in these datasets. As such, our suggestion is to use the data provided to practice your data tidying and plotting techniques, and to consider for yourself what nuances might underlie these relationships.
-- Create a visualization, a model, a [shiny app](https://shiny.posit.co/), or some other piece of data-science-related output, using R or another programming language.
+- Create a visualization, a model, a [Quarto](https://quarto.org/) report, a [shiny app](https://shiny.posit.co/), or some other piece of data-science-related output, using R, Python, or another programming language.
 - [Share your output and the code used to generate it](../../../sharing.md) on social media with the #TidyTuesday hashtag.
-- [Submit your own dataset!](../../../.github/pr_instructions.md)
+- [Submit your own dataset!](../../../.github/pr_instructions.md)  
+
+## TidyTuesday Python Challenge: A collaboration with Posit  
+
+- Exploring the TidyTuesday data in Python and looking for an extra challenge? Use Python to create a [Quarto dashboard](https://quarto.org/docs/dashboards/). Share it with the world using the hashtags #TidyTuesday and #PositPythonChallenge so that Posit has the chance to highlight your work, too!
+- Deploy it however you want! If you'd like a super easy way to publish your dashboard, give [Connect Cloud](https://connect.posit.cloud/) a try.
+- Check out [Posit's Python Challenge repo](https://github.com/posit-dev/python-tidytuesday-challenge) for more information and resources to get you started.

--- a/static/templates/the_data.md
+++ b/static/templates/the_data.md
@@ -1,7 +1,8 @@
 ## The Data
 
 ```r
-# Option 1: tidytuesdayR package 
+# Using R
+# Option 1: tidytuesdayR R package 
 ## install.packages("tidytuesdayR")
 
 tuesdata <- tidytuesdayR::tt_load('{{date}}')
@@ -16,5 +17,22 @@ tuesdata <- tidytuesdayR::tt_load({{year}}, week = {{week}})
 
 {{#datasets}}
 {{{dataset_name}}} <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/main/data/{{year}}/{{date}}/{{dataset_file}}')
+{{/datasets}}
+```
+
+```python
+# Using Python
+# Option 1: PyDyTuesday python library
+## pip install PyDyTuesday
+
+import PyDyTuesday
+
+# Download files from the week, which you can then read in locally
+PyDyTuesday.get_date('{{date}}')
+
+# Option 2: Read directly from GitHub and assign to an object
+
+{{#datasets}}
+{{{dataset_name}}} = pandas.read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/main/data/{{year}}/{{date}}/{{dataset_file}}')
 {{/datasets}}
 ```


### PR DESCRIPTION
Hello, Jon! I've added the python info to the templates in the same way I added it to this week's FBI data readme. I know your script behind the scenes builds each week's readme using params for year and date and so on, and I'm hoping that it will build the python chunk in the same way as the R chunk. The last thing I want to do is make more work for you! 

Libby


Thank you for your submission! Please leave this text as-is when you submit, and then check the checklist.

Usability:

- [ ] This dataset has not already been used in TidyTuesday.
- [ ] The dataset is less than 20MB when saved as a tidy CSV.
- [ ] I can imagine at least one data visualization related to this dataset.

Preparation:

- [ ] `cleaning.R` has code to download and clean the dataset, resulting in descriptively-named data.frames.
- [ ] I ran `saving.R` to create `csv`s and `md` data dictionaries for each of my data.frames.
- [ ] I filled in descriptions for each variable in each of the `{dataset}.md` files.
- [ ] I edited the `intro.md` file to introduce my dataset.
- [ ] I included at least one image for my dataset as a `png` file.
- [ ] I completed the information in `meta.yaml`, including descriptive alt text for each image.
- [ ] I provided information in `meta.yaml` about how to credit me, and deleted any parts of that block that I do not want you to use.
