### PR TITLE
Better intro.md instructions

### DIFF
--- a/.github/workflows/pr-assign-command.yaml
+++ b/.github/workflows/pr-assign-command.yaml
@@ -29,8 +29,14 @@ jobs:
       - name: Assign
         shell: Rscript {0}
         run: |
-          src_folder_name <- strsplit(Sys.getenv("GITHUB_COMMENT_BODY"), " ")[[1]][[2]]
-          target_date <- strsplit(Sys.getenv("GITHUB_COMMENT_BODY"), " ")[[1]][[3]]
+          split_input <- strsplit(Sys.getenv("GITHUB_COMMENT_BODY"), " ")[[1]]
+          target_date <- split_input[[2]]
+          if (length(split_input) > 2) {
+            src_folder_name <- split_input[[3]]
+          } else {
+            src_folder_name <- "new_submission"
+          }
+          
           source("static/templates/assign_week.R", local = TRUE)
 
       - name: commit

--- a/data/curated/template/intro.md
+++ b/data/curated/template/intro.md
@@ -1,15 +1,27 @@
 <!-- 
-1. Describe the dataset. See previous weeks for the general format of the
-DESCRIPTION. The description is the part of the readme.md file above "The Data";
+Describe the dataset. See previous weeks for the general format of the
+description. The description is the part of the readme.md file above "The Data";
 everything else will be filled in from the other md files in this directory +
 automatic scripts. We usually include brief introduction along the lines of
 "This week we're exploring DATASET" or "The dataset this week comes from 
-SOURCE", then a quote starting with ">", then a few questions participants might
-seek to answer using the data. 
-2. Delete this comment block.
+SOURCE".
 -->
-DESCRIPTION
 
-> QUOTE FROM THE SOURCE
+<!-- Add a quote from the source, starting lines with a ">" character, like 
+this:
+> Plant traits are critical to plant form and function — including growth, 
+> survival and reproduction — and therefore shape fundamental aspects of
+> population and ecosystem dynamics as well as ecosystem services. Here, we 
+> present a global species-level compilation of key functional traits for palms 
+> (Arecaceae), a plant family with keystone importance in tropical and 
+> subtropical ecosystems.
+-->
 
-QUESTION?
+> PasteQuoteHere
+
+<!--
+Optional: Add questions that users should try to answer. For example:
+- How does the sizes of the different species of palms vary across sub families?
+- Which fruit colors occur most often?
+-->
+

--- a/static/templates/assign_week.R
+++ b/static/templates/assign_week.R
@@ -25,8 +25,6 @@ metadata <- read_metadata(fs::path(src_dir, "meta.yaml"))
 dataset_files <- fs::dir_ls(src_dir, glob = "*.csv") |> unname()
 dataset_filenames <- basename(dataset_files)
 
-intro <- readLines(fs::path(src_dir, "intro.md"))
-
 title <- metadata$title %||% stop("missing data")
 data_title <- metadata$data_source$title %||% stop("missing data")
 data_link <- metadata$data_source$url %||% stop("missing data")
@@ -80,15 +78,12 @@ fs::file_copy(dataset_files, target_dir)
 
 ## Create readme ---------------------------------------------------------------
 
-read_piece <- function(filename) {
-  paste(readLines(filename, warn = FALSE), collapse = "\n")
-}
+source(here::here("static", "templates", "readme.R"), local = TRUE)
 
 title_line <- glue::glue("# {title}")
 intro <- read_piece(fs::path(src_dir, "intro.md"))
 credit_line <- glue::glue("Thank you to {credit} for curating this week's dataset.")
 if (length(credit_line)) {
-  
   intro <- paste(intro, credit_line, sep = "\n\n")
 }
 

--- a/static/templates/readme.R
+++ b/static/templates/readme.R
@@ -1,0 +1,7 @@
+read_piece <- function(filename) {
+  readLines(filename, warn = FALSE) |> 
+    paste(collapse = "\n") |> 
+    stringr::str_remove_all("<!--[\\s\\S]*?-->") |> 
+    stringr::str_trim() |> 
+    stringr::str_c("\n")
+}

--- a/tidytuesday.Rproj
+++ b/tidytuesday.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 3f5aad19-3130-4147-9590-fca99109befb
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
Lay out intro.md to try to make it harder for submitters to get confused.

I also updated the curation script to remove comments from things like intro.md, and updated the assign workflow to use the tidytuesdayR default "new_submission" folder if no folder is specified.

Closes #752.
