### PR TITLE
Merge main before accept.

### DIFF
--- a/.github/workflows/pr-assign-command.yaml
+++ b/.github/workflows/pr-assign-command.yaml
@@ -19,6 +19,15 @@ jobs:
       - uses: r-lib/actions/pr-fetch@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Merge main into PR branch
+        run: |
+          git fetch origin main
+          if ! git merge --no-edit origin/main; then
+            echo "❌ Merge conflict: manually merge the main branch before accepting this PR."
+            exit 1
+          fi
+        shell: bash
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
In theory this should automatically merge the main branch into the PR before trying to accept the submission.

Closes #740.