### PR TITLE
Lowercase 'pydytuesday' in readme.md

### DIFF
--- a/data/2025/2025-04-22/readme.md
+++ b/data/2025/2025-04-22/readme.md
@@ -54,12 +54,12 @@ daily_accidents_420 <- readr::read_csv('https://raw.githubusercontent.com/rforda
 ```python
 # Using Python
 # Option 1: PyDyTuesday python library
-## pip install PyDyTuesday
+## pip install pydytuesday
 
-import PyDyTuesday
+import pydytuesday
 
 # Download files from the week, which you can then read in locally
-PyDyTuesday.get_date('2025-04-22')
+pydytuesday.get_date('2025-04-22')
 
 # Option 2: Read directly from GitHub and assign to an object
 


### PR DESCRIPTION
I could not figure out why the python snippet would not work for me, even after 'pip install pydytuesday' was successful.

It was a matter of lower-casing the module name. 

I'm not a senior Python dev, and I don't know if this is specific to my setup, but if it's not, then maybe you can lowercase the readme script so other people don't get tripped up.