### PR TITLE
Update data dictionary entry for Last season var

### DIFF
--- a/data/2025/2025-10-07/readme.md
+++ b/data/2025/2025-10-07/readme.md
@@ -91,7 +91,7 @@ euroleague_basketball = CSV.read("https://raw.githubusercontent.com/rfordatascie
 |Home city                      |character |City where the team is based.                                               |
 |Arena                          |character |Name of the home arena.                                                     |
 |Capacity                       |character |Seating capacity of the arena.                                              |
-|Last season                    |character |Last season in which the team participated.                                 |
+|Last season                    |character |Ranking of team in the 2024-25 season, including teams elevated to the Euroleague from the Eurocup in that season.|
 |Country                        |character |Country where the team is based.                                            |
 |FinalFour_Appearances          |integer    |Number of times the team has reached the EuroLeague Final Four.             |
 |Titles_Won                     |integer    |Number of EuroLeague titles won by the team.                                |


### PR DESCRIPTION
After reading the attached wikipedia article, Nelly, Nur, and I realized that the "Last season" data dictionary definition was inaccurate. We've corrected it to a more clear definition with a little more domain context. Upon reading up on the Euroleague, it seems like the standings are the places in which the teams finished in the Euroleague games, except for the final four, whose rankings reflect their standing after the final four match-ups. Rankings for the 2024-25 season can also be seen here: https://www.euroleaguebasketball.net/euroleague/standings/?season=2024-25&type=Traditional&phase=REGULAR%20SEASON