### PR TITLE
Fix formatting of mastodon entry in meta.yaml

### DIFF
--- a/data/curated/template/meta.yaml
+++ b/data/curated/template/meta.yaml
@@ -17,5 +17,5 @@ credit:
   post: YOUR NAME AND AFFILIATION FOR CREDIT IN POST
   bluesky: https://bsky.app/profile/YOURNAME
   linkedin: https://www.linkedin.com/in/YOURNAME
-  mastodon: @YOURNAME@YOURSERVER
+  mastodon: "@YOURNAME@YOURSERVER"
   github: https://github.com/YOURNAME


### PR DESCRIPTION
Tiny little update to the `meta.yaml` template file to put the mastodon entry in quotation marks. Otherwise the `@` causes the automated checks to fail.
