### PR TITLE
Keep PR pieces

### DIFF
--- a/data/2024/2024-04-30/readme.md
+++ b/data/2024/2024-04-30/readme.md
@@ -83,8 +83,7 @@ wwbi_country <- readr::read_csv('https://raw.githubusercontent.com/rfordatascien
 |external_debt_reporting_status |character |estimate, preliminary, or actual |
 |system_of_trade  |character |Under the general system imports include goods imported for domestic consumption and imports into bonded warehouses and free trade zones. Under the special system imports comprise goods imported for domestic consumption (including transformation and repair) and withdrawals for domestic consumption from bonded warehouses and free trade zones. Goods transported through a country en route to another are excluded. |
 |government_accounting_concept |character |government accounting concept |
-|imf_data_dissemination_standard |character |International Monetary Fund data-dissemination standard: Special Data Dissemination Standard (SDDS, 1996, created for countries
-that have or seek to have access to international markets), SDDS Plus (2012, the highest tier of data standards, intended for systemically important economies), enhanced GDDS (e-GDDS, 2015, encouraging participants to emphasize data publication) |
+|imf_data_dissemination_standard |character |International Monetary Fund data-dissemination standard: Special Data Dissemination Standard (SDDS, 1996, created for countries that have or seek to have access to international markets), SDDS Plus (2012, the highest tier of data standards, intended for systemically important economies), enhanced GDDS (e-GDDS, 2015, encouraging participants to emphasize data publication) |
 |latest_household_survey |character |which household survey was most recently administered |
 |source_of_most_recent_income_and_expenditure_data |character |which survey serves as the basis for income and expenditure data |
 |vital_registration_complete |logical |whether the vital registration is complete |

--- a/data/2024/2024-05-21/readme.md
+++ b/data/2024/2024-05-21/readme.md
@@ -48,8 +48,7 @@ emissions <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/
 |commodity              |character |Specifies which commodity the production refers to: Oil and NGL, Natural Gas, Anthracite Coal, Bituminous Coal, Lignite Coal, Metallurgical Coal, Sub-Bituminous Coal, Thermal Coal, or Cement.  |
 |production_value       |double    |The quantity of production    |
 |production_unit        |character |The unit of production (Oil & NGL - million barrels, Natural Gas - billion cubic feet, Coal - million tonnes, Cement - million tonnes CO2 (see methodology for explanation)). Units - Billion cubic feet per year (Bcf/yr), Million barrels per year (Million bbl/yr), or Million tonnes per year (Million tonnes/yr).  |
-|total_emissions_MtCO2e |double    |The total emissions traced to
-the 'parent_entity' in the 'year'. Units - million tonnes of carbon dioxide equivalent (MtCO2e). |
+|total_emissions_MtCO2e |double    |The total emissions traced to the 'parent_entity' in the 'year'. Units - million tonnes of carbon dioxide equivalent (MtCO2e). |
 
 
 

--- a/data/2024/2024-07-16/readme.md
+++ b/data/2024/2024-07-16/readme.md
@@ -63,11 +63,11 @@ ewf_standings <- readr::read_csv('https://raw.githubusercontent.com/rfordatascie
 | division        |character  | The division name in English football.|
 | match_id        |character  | The unique ID for the match. Has the format `M-####-####-#-###-M`, where the first number is the year in which the season started, the second number is the year in which the season ended, the third number is the tier, and the fourth number is a counter that is assigned to the data when sorted by the match's date, then by the name of the home team, and then by the name of the away team. References `match_id` in the `ewf_matches` dataset.|
 | match_name      |character  | The name of the match, where the name of the home team and the name of the away team is separated by ' vs '.|
-| date            |date  | The date of the match, in `yyyy-mm-dd` format.|
+| date            |date       | The date of the match, in `yyyy-mm-dd` format.|
 | attendance      |character  | The total crowd attendance at the match. Note that this information is not available for some matches.|
 | team_id         |character  | The unique ID for the team. Has the format `T-###-T`.|
 | team_name       |character  | The name of the team at the match.|
-| opponent_id| The unique ID for the team’s opponent. Has the format `T-###-T`.|
+| opponent_id     |character  | The unique ID for the team’s opponent. Has the format `T-###-T`.|
 | opponent_name   |character  | The name of the team’s opponent at the match.|
 | home_team       |integer    | Whether the team was the home team. Possible value are `1` if the team was the home team and `0` otherwise.|
 | away_team       |integer    | Whether the team was the away team. Possible value are `1` if the team was the away team and `0` otherwise.|
@@ -91,7 +91,7 @@ ewf_standings <- readr::read_csv('https://raw.githubusercontent.com/rfordatascie
 | division              |character  | The division name in English football.|
 | match_id              |character  | The unique ID for the match. Has the format `M-####-####-#-###-M`, where the first number is the year in which the season started, the second number is the year in which the season ended, the third number is the tier, and the fourth number is a counter that is assigned to the data when sorted by the match's date, then by the name of the home team, and then by the name of the away team.|
 | match_name            |character  | The name of the match, where the name of the home team and the name of the away team is separated by ' vs '.|
-| date                  |date  | The date of the match, in `yyyy-mm-dd` format.|
+| date                  |date       | The date of the match, in `yyyy-mm-dd` format.|
 | attendance            |character  | The total crowd attendance at the match. Note that this information is not available for some matches.|
 | home_team_id          |character  | The unique ID for the home team. Has the format `T-###-T`.|
 | home_team_name        |character  | The name of the home team at the match.|

--- a/data/2025/2025-09-23/readme.md
+++ b/data/2025/2025-09-23/readme.md
@@ -94,7 +94,7 @@ fide_ratings_september = CSV.read("https://raw.githubusercontent.com/rfordatasci
 |:--------|:---------|:-------------------------------------|
 |id       |integer   |Identification number of a player within FIDE database. |
 |name     |character |Player name. |
-|fed      |character |Federation of player. Similar, but not identical to, IOC country codes. An unofficial list is available [here](https://www.mark-weeks.com/aboutcom/mw15b16.htm|) |
+|fed      |character |Federation of player. Similar, but not identical to, IOC country codes. An unofficial list is available [here](https://www.mark-weeks.com/aboutcom/mw15b16.htm) |
 |sex      |character |Sex of player (M - male, F - female) |
 |title    |character |Title of a player (GM - Grand Master, WGM - Woman Grand Master, IM - International Master, WIM - Woman International Master, FM - FIDE Master, WFM - Woman FIDE Master, CM - Candidate Master, WCM - Woman Candidate Master) |
 |wtitle   |character |Woman title of a player (WGM - Woman Grand Master, WIM - Woman International Master, WFM - Woman FIDE Master, WCM - Woman Candidate Master) |
@@ -111,7 +111,7 @@ fide_ratings_september = CSV.read("https://raw.githubusercontent.com/rfordatasci
 |:--------|:---------|:-------------------------------------|
 |id       |integer   |Identification number of a player within FIDE database. |
 |name     |character |Player name. |
-|fed      |character |Federation of player. Similar, but not identical to, IOC country codes. An unofficial list is available [here](https://www.mark-weeks.com/aboutcom/mw15b16.htm|) |
+|fed      |character |Federation of player. Similar, but not identical to, IOC country codes. An unofficial list is available [here](https://www.mark-weeks.com/aboutcom/mw15b16.htm) |
 |sex      |character |Sex of player (M - male, F - female) |
 |title    |character |Title of a player (GM - Grand Master, WGM - Woman Grand Master, IM - International Master, WIM - Woman International Master, FM - FIDE Master, WFM - Woman FIDE Master, CM - Candidate Master, WCM - Woman Candidate Master) |
 |wtitle   |character |Woman title of a player (WGM - Woman Grand Master, WIM - Woman International Master, WFM - Woman FIDE Master, WCM - Woman Candidate Master) |


### PR DESCRIPTION
Right now I delete the README sub-pieces when I accept a dataset. However, on the new site, I will use those pieces to build the parts of the website that are customized to a given dataset, so let's keep them rather than forcing me to re-extract them.

I also fixed some ~typos in various datasets.