### PR TITLE
Use tt_load in data template for TidierTuesday example

### DIFF
--- a/static/templates/the_data.md
+++ b/static/templates/the_data.md
@@ -44,7 +44,7 @@ pydytuesday.get_date('{{date}}')
 
 using TidierTuesday
 
-# Download files from the week, which you can then read in locally
+# Download datasets for the week, and load them as a NamedTuple of DataFrames
 data = tt_load("{{date}}")
 
 # Option 2: Read directly from GitHub and assign to an object with TidierFiles


### PR DESCRIPTION
This changes the code snippet for TidierTuesday in the data subfolders in the template.

I tried copy pasting this and it threw a Character error because it uses ' instead of " as a string delimiter.

According to the TidierTuesday docs the recommendation should be tt_load(date) instead. 

I hope I changed the template correctly. 

