### PR TITLE
Remove extra ticks from old dictionaries

### DIFF
--- a/data/2025/2025-12-23/endangered_status.md
+++ b/data/2025/2025-12-23/endangered_status.md
@@ -1,6 +1,6 @@
 | Variable | Class | Description |
 |----------------|-----------|-------------------------------------------------|
-| `id` | character | Unique identifier for language |
-| `status_code` | character | Code of the agglomerated endangerment status (1–6) |
-| `status_label` | character | Descriptive label of endangerment category |
+| id | character | Unique identifier for language |
+| status_code | character | Code of the agglomerated endangerment status (1–6) |
+| status_label | character | Descriptive label of endangerment category |
 

--- a/data/2025/2025-12-23/families.md
+++ b/data/2025/2025-12-23/families.md
@@ -1,5 +1,5 @@
 | Variable | Class     | Description                           |
 |----------|-----------|---------------------------------------|
-| `id`     | character | Unique identifier for language family |
-| `name`   | character | Language family name                  |
+| id     | character | Unique identifier for language family |
+| name   | character | Language family name                  |
 

--- a/data/2025/2025-12-23/languages.md
+++ b/data/2025/2025-12-23/languages.md
@@ -1,12 +1,12 @@
 | Variable | Class | Description |
 |----|----|----|
-| `id` | character | Unique identifier for language |
-| `name` | character | Language name |
-| `macroarea` | character | General geographic area in which the language is found |
-| `latitude` | double | Latitude of language location (as point) |
-| `longitude` | double | Longitude of language location (as point) |
-| `iso639p3code` | character | ISO 639-3 identifier of language (if available) |
-| `countries` | character | Countries in which language is used (separated by ";") |
-| `is_isolate` | logical | Whether language is an isolate (i.e. has no known relatives) |
-| `family_id` | character | Unique identifier of family that the language is part of (if not isolate) |
+| id | character | Unique identifier for language |
+| name | character | Language name |
+| macroarea | character | General geographic area in which the language is found |
+| latitude | double | Latitude of language location (as point) |
+| longitude | double | Longitude of language location (as point) |
+| iso639p3code | character | ISO 639-3 identifier of language (if available) |
+| countries | character | Countries in which language is used (separated by ";") |
+| is_isolate | logical | Whether language is an isolate (i.e. has no known relatives) |
+| family_id | character | Unique identifier of family that the language is part of (if not isolate) |
 


### PR DESCRIPTION
Removes backtick characters wrapping variable names in the first column of older data dictionary `.md` files, where such formatting was inconsistent with the current standard.

## Changes Made

- Removed backtick wrapping from variable names in the first column of:
  - `data/2025/2025-12-23/endangered_status.md`
  - `data/2025/2025-12-23/families.md`
  - `data/2025/2025-12-23/languages.md`
- Audited all other `data/YYYY/YYYY-MM-DD/*.md` files (excluding `intro.md` and `readme.md`) for tick characters; no additional first-column ticks were found. Remaining ticks in description columns serve as legitimate markdown code formatting (e.g., cross-table references, `NA` sentinel values, factor levels) and were left in place.